### PR TITLE
Use-after-free

### DIFF
--- a/src/graph/peered/All.cpp
+++ b/src/graph/peered/All.cpp
@@ -119,7 +119,7 @@ namespace ragedb {
             }
 
             auto p2 = make_shared(std::move(futures));
-            return seastar::when_all_succeed(p2->begin(), p2->end()).then([limit] (const std::vector<std::vector<uint64_t>>& results) {
+            return seastar::when_all_succeed(p2->begin(), p2->end()).then([limit, p2] (const std::vector<std::vector<uint64_t>>& results) {
                 std::vector<uint64_t> ids;
                 ids.reserve(limit);
                 for (auto result : results) {


### PR DESCRIPTION
NOTE: not even compile tested. btw, if you don't store a ref to shared ptr in lambda, p2 may be destroyed after when_all_succeed() defers. note that seastar projects like scylladb use do_with() to handle this, or just store a ref to shared ptr in lambda like done by this fix.