### PR TITLE
fix(gql): stop IrreflexiveContradictionPruner returning empty for satisfiable queries

### DIFF
--- a/src/gql/optimizer/IrreflexiveContradictionPruner.cpp
+++ b/src/gql/optimizer/IrreflexiveContradictionPruner.cpp
@@ -91,6 +91,9 @@ void IrreflexiveContradictionPruner::irreflexive_contradiction_pass(GqlQuery& qu
         collect_equalities(query.where_expr.get(), node_eq);
     }
     for (const auto& match : query.matches) {
+        // An equality inside an OPTIONAL MATCH only filters that optional binding; it must not
+        // make the whole query a contradiction.
+        if (match.is_optional) continue;
         for (const auto& node : match.pattern.nodes) {
             if (node.where_expr) {
                 collect_equalities(node.where_expr.get(), node_eq);
@@ -109,13 +112,20 @@ void IrreflexiveContradictionPruner::irreflexive_contradiction_pass(GqlQuery& qu
         
         for (size_t i = 0; i < match.pattern.edges.size(); ++i) {
             const auto& edge = match.pattern.edges[i];
+            // Irreflexivity forbids only a DIRECT (1-hop) self-loop. A variable-length edge can
+            // reach the same node via a longer path (e.g. *2..2 = a->b->a), which is satisfiable.
+            if (edge.is_variable_length) continue;
             if (edge.label_expr && edge.label_expr->kind == LabelExprKind::LITERAL) {
                 std::string rel_type = edge.label_expr->name;
-                
+
                 if (GqlVirtualCatalog::local().has_relationship_algebraic_property(rel_type, "irreflexive")) {
                     std::string src = match.pattern.nodes[i].variable;
                     std::string tgt = match.pattern.nodes[i + 1].variable;
-                    
+
+                    // Anonymous endpoints are DISTINCT nodes, not a self-loop; only prune when the
+                    // two endpoints are the same named variable (or provably equal via WHERE).
+                    if (src.empty() || tgt.empty()) continue;
+
                     if (are_equal_vars(src, tgt, node_eq)) {
                         // Impossible self-loop on an irreflexive relationship!
                         query.no_op = true;

--- a/test/gql/optimizer/AlglibOptimizerTests.cpp
+++ b/test/gql/optimizer/AlglibOptimizerTests.cpp
@@ -99,6 +99,36 @@ TEST_CASE("GQL Optimizer Phase 24: Irreflexive Contradiction Pruner", "[gql_opti
     }
 }
 
+// Negative controls (task 005): the irreflexive pruner must NOT no_op these -- each is satisfiable.
+TEST_CASE("GQL Optimizer Phase 24: Irreflexive pruner negative controls", "[gql_optimizer][alglib][task005]") {
+    GqlVirtualCatalog::local().clear();
+    GqlVirtualCatalog::local().set_relationship_algebraic_properties("parent_of", {"irreflexive"});
+
+    SECTION("Anonymous endpoints are distinct nodes, not a self-loop") {
+        auto query = GqlParser::parse("MATCH ()-[:parent_of]->() RETURN count(*)");
+        GqlOptimizer::optimize(query);
+        REQUIRE(query.no_op == false);
+    }
+
+    SECTION("Variable-length edge can form a longer cycle a->b->a (satisfiable)") {
+        auto query = GqlParser::parse("MATCH (a)-[:parent_of*2..2]->(a) RETURN a");
+        GqlOptimizer::optimize(query);
+        REQUIRE(query.no_op == false);
+    }
+
+    SECTION("Equality inside a disjunction must not force a contradiction") {
+        auto query = GqlParser::parse("MATCH (a)-[:parent_of]->(b) WHERE a = b OR a.x = 1 RETURN a");
+        GqlOptimizer::optimize(query);
+        REQUIRE(query.no_op == false);
+    }
+
+    SECTION("Positive control still fires: a genuine direct self-loop is a contradiction") {
+        auto query = GqlParser::parse("MATCH (a)-[:parent_of]->(a) RETURN a");
+        GqlOptimizer::optimize(query);
+        REQUIRE(query.no_op == true);
+    }
+}
+
 TEST_CASE("GQL Optimizer Phase 25: Antisymmetric Loop Collapse", "[gql_optimizer][alglib]") {
     SECTION("Antisymmetric but not reflexive - should collapse to self-loop") {
         GqlVirtualCatalog::local().clear();


### PR DESCRIPTION
The irreflexive-contradiction pruner marked whole queries `no_op` (silently empty results) in three sound cases:

- **Anonymous endpoints**: `are_equal_vars("","")` returned true, so `MATCH ()-[:R]->()` on an irreflexive `R` was pruned -- but two anonymous nodes are distinct. Now skips when either endpoint variable is empty.
- **Variable-length edges**: `MATCH (a)-[:R*2..2]->(a)` is satisfiable (a->b->a); irreflexivity forbids only a direct 1-hop self-loop. Now skips `is_variable_length` edges.
- **OPTIONAL MATCH equalities**: an equality inside an OPTIONAL MATCH only filters the optional binding, so it must not contribute to a whole-query contradiction. Now skips optional matches when collecting equalities.

## Verification

Red->green on the box: the negative-control tests fail on the original pruner (anonymous + variable-length wrongly `no_op`) and pass with the fix; a positive control confirms a genuine direct self-loop still fires. `WHERE a=b OR ...` was already safe (collect_equalities ignores OR).

Deferred (see review notes): `x.id = y.id` is treated as node identity even when `id` is a user property -- needs a convention decision.