### PR TITLE
fix(gql): guard TransitivePathOptimizer against unsound transitive rewrites

### DIFF
--- a/src/gql/optimizer/TransitivePathOptimizer.cpp
+++ b/src/gql/optimizer/TransitivePathOptimizer.cpp
@@ -18,6 +18,7 @@
 #include "../GqlVirtualCatalog.h"
 #include <unordered_map>
 #include <unordered_set>
+#include <limits>
 
 namespace ragedb::gql {
 
@@ -60,7 +61,20 @@ void TransitivePathOptimizer::transitive_path_pass(GqlQuery& query) {
                     GqlVirtualCatalog::local().has_relationship_algebraic_property(rel_type, "symmetric") &&
                     GqlVirtualCatalog::local().has_relationship_algebraic_property(rel_type, "transitive");
 
-                if (is_transitive && !is_equivalence) {
+                // The transitive-reachability fast path (Case 0.6) only reproduces the original
+                // traversal for a simple, unbounded, RIGHT-directed hop with no edge binding/
+                // predicates, no path variable, and no shortest-path selector. Guard against every
+                // case it would silently get wrong: hop bounds (*2..2, *0..), direction (LEFT/ANY),
+                // edge predicates/variable, a bound path, or a shortest-path selector.
+                bool safe_to_rewrite =
+                    edge.direction == EdgeDirection::RIGHT &&
+                    edge.min_hops == 1 && edge.max_hops == std::numeric_limits<uint64_t>::max() &&
+                    edge.variable.empty() &&
+                    edge.properties.empty() && edge.property_filters.empty() && !edge.where_expr &&
+                    match.path_variable.empty() &&
+                    match.shortest_path_kind == ShortestPathKind::NONE;
+
+                if (is_transitive && !is_equivalence && safe_to_rewrite) {
                     match.transitive_reachability_lookup = true;
                     edge.is_variable_length = false;
                     edge.min_hops = 1;
@@ -121,8 +135,18 @@ void TransitivePathOptimizer::transitive_path_pass(GqlQuery& query) {
                         dst = match.pattern.nodes[0].variable;
                     }
                     if (!src.empty() && !dst.empty()) {
+                        // Only prune a shortcut edge that carries no constraints and binds nothing --
+                        // otherwise pruning would silently drop labels/properties/filters or leave an
+                        // edge/path variable unbound.
+                        const auto& n0 = match.pattern.nodes[0];
+                        const auto& n1 = match.pattern.nodes[1];
+                        bool unconstrained =
+                            !n0.label_expr && n0.properties.empty() && n0.property_filters.empty() && !n0.where_expr &&
+                            !n1.label_expr && n1.properties.empty() && n1.property_filters.empty() && !n1.where_expr &&
+                            edge.properties.empty() && edge.property_filters.empty() && !edge.where_expr &&
+                            edge.variable.empty() && match.path_variable.empty();
                         std::unordered_set<std::string> visited;
-                        if (is_reachable_min_depth_2(src, dst, rel_adj[rel_type], visited, 0)) {
+                        if (unconstrained && is_reachable_min_depth_2(src, dst, rel_adj[rel_type], visited, 0)) {
                             prune = true;
                         }
                     }

--- a/test/gql/optimizer/AlglibOptimizerTests.cpp
+++ b/test/gql/optimizer/AlglibOptimizerTests.cpp
@@ -78,6 +78,44 @@ TEST_CASE("GQL Optimizer Phase 23: Transitive Path Pruning", "[gql_optimizer][al
     }
 }
 
+// Guards (task 003): the transitive-reachability rewrite must NOT fire for patterns the fast path
+// gets wrong, and shortcut pruning must not drop constrained/bound matches.
+TEST_CASE("GQL Optimizer Phase 23: transitive rewrite guards", "[gql_optimizer][alglib][task003]") {
+    GqlVirtualCatalog::local().clear();
+    GqlVirtualCatalog::local().set_relationship_algebraic_properties("ancestor_of", {"transitive"});
+
+    SECTION("bounded hops *2..2 are not rewritten") {
+        auto q = GqlParser::parse("MATCH (a)-[:ancestor_of*2..2]->(b) RETURN a, b");
+        GqlOptimizer::optimize(q);
+        REQUIRE(q.matches[0].transitive_reachability_lookup == false);
+    }
+    SECTION("zero-lower-bound *0.. is not rewritten") {
+        auto q = GqlParser::parse("MATCH (a)-[:ancestor_of*0..]->(b) RETURN a, b");
+        GqlOptimizer::optimize(q);
+        REQUIRE(q.matches[0].transitive_reachability_lookup == false);
+    }
+    SECTION("LEFT direction is not rewritten") {
+        auto q = GqlParser::parse("MATCH (a)<-[:ancestor_of*]-(b) RETURN a, b");
+        GqlOptimizer::optimize(q);
+        REQUIRE(q.matches[0].transitive_reachability_lookup == false);
+    }
+    SECTION("a bound edge variable is not rewritten") {
+        auto q = GqlParser::parse("MATCH (a)-[r:ancestor_of*]->(b) RETURN r");
+        GqlOptimizer::optimize(q);
+        REQUIRE(q.matches[0].transitive_reachability_lookup == false);
+    }
+    SECTION("the safe *1.. case is still rewritten") {
+        auto q = GqlParser::parse("MATCH (a)-[:ancestor_of*]->(b) RETURN a, b");
+        GqlOptimizer::optimize(q);
+        REQUIRE(q.matches[0].transitive_reachability_lookup == true);
+    }
+    SECTION("a shortcut carrying an edge variable is not pruned") {
+        auto q = GqlParser::parse("MATCH (x)-[:ancestor_of]->(y) MATCH (y)-[:ancestor_of]->(z) MATCH (x)-[e:ancestor_of]->(z) RETURN x, y, z, e");
+        GqlOptimizer::optimize(q);
+        REQUIRE(q.matches.size() == 3);
+    }
+}
+
 TEST_CASE("GQL Optimizer Phase 24: Irreflexive Contradiction Pruner", "[gql_optimizer][alglib]") {
     GqlVirtualCatalog::local().clear();
     GqlVirtualCatalog::local().set_relationship_algebraic_properties("parent_of", {"irreflexive"});


### PR DESCRIPTION
The transitive-reachability rewrite set `transitive_reachability_lookup` for **any** variable-length match on a transitive relation, but the fast path (Case 0.6) only reproduces the original traversal for a simple unbounded RIGHT hop. So `*2..2`/`*1..3` ignored hop bounds, `*0..` dropped mandatory 0-hop rows, `LEFT`/`ANY` reversed/lost direction, and edge predicates/variables, a bound path variable, and `ANY SHORTEST` were silently dropped/hijacked -- all wrong results.

## Change

Guard the rewrite to fire only for: direction RIGHT, hops `*1..` (min 1, unbounded), no edge variable, no edge predicate, no path variable, no shortest-path selector -- otherwise fall back to normal execution.

Also guard shortcut-edge pruning to skip any match that carries a label/property/filter or binds an edge/path variable, so pruning can no longer drop constraints or leave a variable unbound.

## Verification

Red->green on the box: original rewrites `*2..2`, `*0..`, `LEFT`, and a bound edge variable (5 failing assertions incl. a wrongly-pruned edge-var shortcut); all pass with the guard; the safe `*1..` case still rewrites.

Deferred (see notes): cyclic mutual-justification in shortcut pruning (iterative adjacency) and row-multiplicity with parallel edges.