### PR TITLE
fix(gql): guard EquivalenceClassOptimizer against unsound rewrites

### DIFF
--- a/src/gql/optimizer/EquivalenceClassOptimizer.cpp
+++ b/src/gql/optimizer/EquivalenceClassOptimizer.cpp
@@ -16,6 +16,7 @@
 
 #include "EquivalenceClassOptimizer.h"
 #include "../GqlVirtualCatalog.h"
+#include <limits>
 
 namespace ragedb::gql {
 
@@ -35,7 +36,19 @@ void EquivalenceClassOptimizer::equivalence_class_pass(GqlQuery& query) {
                     GqlVirtualCatalog::local().has_relationship_algebraic_property(rel_type, "symmetric") &&
                     GqlVirtualCatalog::local().has_relationship_algebraic_property(rel_type, "transitive");
 
-                if (is_equivalence) {
+                // The equivalence-partition fast path (Case 0.5) only reproduces the original
+                // traversal for a simple, unbounded, RIGHT-directed hop with no edge binding/
+                // predicates, no path variable, and no shortest-path selector. Guard against every
+                // case it would silently get wrong (hop bounds, direction, predicates, bindings).
+                bool safe_to_rewrite =
+                    edge.direction == EdgeDirection::RIGHT &&
+                    edge.min_hops == 1 && edge.max_hops == std::numeric_limits<uint64_t>::max() &&
+                    edge.variable.empty() &&
+                    edge.properties.empty() && edge.property_filters.empty() && !edge.where_expr &&
+                    match.path_variable.empty() &&
+                    match.shortest_path_kind == ShortestPathKind::NONE;
+
+                if (is_equivalence && safe_to_rewrite) {
                     match.equivalence_partition_lookup = true;
                     edge.is_variable_length = false;
                     edge.min_hops = 1;

--- a/test/gql/optimizer/AlglibOptimizerTests.cpp
+++ b/test/gql/optimizer/AlglibOptimizerTests.cpp
@@ -147,3 +147,31 @@ TEST_CASE("GQL Optimizer Phase 26: Equivalence Class Coalescing", "[gql_optimize
     REQUIRE(match.pattern.edges[0].min_hops == 1);
     REQUIRE(match.pattern.edges[0].max_hops == 1);
 }
+
+// Guards (task 004): the equivalence-partition rewrite must NOT fire for patterns the fast path
+// gets wrong (bounded hops, direction, bound edge variable, predicates, path var, shortest).
+TEST_CASE("GQL Optimizer Phase 26: equivalence rewrite guards", "[gql_optimizer][alglib][task004]") {
+    GqlVirtualCatalog::local().clear();
+    GqlVirtualCatalog::local().set_relationship_algebraic_properties("same_group", {"reflexive", "symmetric", "transitive"});
+
+    SECTION("bounded hops *2..3 are not rewritten") {
+        auto q = GqlParser::parse("MATCH (a)-[:same_group*2..3]->(b) RETURN a, b");
+        GqlOptimizer::optimize(q);
+        REQUIRE(q.matches[0].equivalence_partition_lookup == false);
+    }
+    SECTION("LEFT direction is not rewritten") {
+        auto q = GqlParser::parse("MATCH (a)<-[:same_group*]-(b) RETURN a, b");
+        GqlOptimizer::optimize(q);
+        REQUIRE(q.matches[0].equivalence_partition_lookup == false);
+    }
+    SECTION("a bound edge variable is not rewritten") {
+        auto q = GqlParser::parse("MATCH (a)-[r:same_group*]->(b) RETURN r");
+        GqlOptimizer::optimize(q);
+        REQUIRE(q.matches[0].equivalence_partition_lookup == false);
+    }
+    SECTION("the safe *1.. case is still rewritten") {
+        auto q = GqlParser::parse("MATCH (a)-[:same_group*]->(b) RETURN a, b");
+        GqlOptimizer::optimize(q);
+        REQUIRE(q.matches[0].equivalence_partition_lookup == true);
+    }
+}


### PR DESCRIPTION
Mirror of the transitive guard (#49): the equivalence-partition rewrite set `equivalence_partition_lookup` for any variable-length match on an equivalence relation, but the fast path (Case 0.5) only reproduces the original traversal for a simple unbounded RIGHT hop. So `*2..3` returned the whole partition, `LEFT` was mishandled, and edge predicates/variables, a bound path variable, and `ANY SHORTEST` were silently dropped/hijacked.

Guard the rewrite to fire only for direction RIGHT, hops `*1..`, no edge variable/predicate, no path variable, no shortest selector.

## Verification
Red->green on the box: original rewrites `*2..3`, `LEFT`, and a bound edge variable (3 failing assertions); all pass with the guard; the safe `*1..` case still rewrites.

## Deferred design decisions (need a call)
The equivalence fast path also has semantics issues beyond the rewrite guard, left for a decision: whole-graph reflexivity (WCC seeds every node as its own class -> `(n,n)` for unrelated nodes), TRAIL row-multiplicity vs one-row-per-pair, and the unimplemented `domain` restriction. The virtualized-closure semantics is assumed but undocumented. I did not change executor semantics pending that decision.