### PR TITLE
fix(gql): stop AntisymmetricLoopCollapser dropping labels/constraints

### DIFF
--- a/src/gql/optimizer/AntisymmetricLoopCollapser.cpp
+++ b/src/gql/optimizer/AntisymmetricLoopCollapser.cpp
@@ -28,6 +28,19 @@ namespace ragedb::gql {
 namespace {
 
 void merge_pattern_nodes(PatternNode& dest, PatternNode& src) {
+    // Preserve src's label constraint: the merged node must satisfy BOTH labels, so combine them
+    // with AND rather than dropping src's label (which silently widened the result).
+    if (src.label_expr) {
+        if (dest.label_expr) {
+            auto both = std::make_shared<LabelExpression>();
+            both->kind = LabelExprKind::AND;
+            both->left = dest.label_expr;
+            both->right = src.label_expr;
+            dest.label_expr = both;
+        } else {
+            dest.label_expr = src.label_expr;
+        }
+    }
     for (const auto& [k, v] : src.properties) {
         dest.properties[k] = v;
     }
@@ -107,6 +120,7 @@ void prune_redundant_single_node_matches(GqlQuery& query) {
             it->pattern.edges.empty() && it->pattern.nodes.size() == 1) {
             std::string var = it->pattern.nodes[0].variable;
             if (bound_vars.count(var) > 0 &&
+                !it->pattern.nodes[0].label_expr &&
                 it->pattern.nodes[0].properties.empty() &&
                 it->pattern.nodes[0].property_filters.empty() &&
                 !it->pattern.nodes[0].where_expr) {
@@ -141,7 +155,12 @@ void AntisymmetricLoopCollapser::antisymmetric_loop_pass(GqlQuery& query) {
             if (match.is_optional || match.is_search || match.is_khop) continue;
             for (size_t e_idx = 0; e_idx < match.pattern.edges.size(); ++e_idx) {
                 const auto& edge = match.pattern.edges[e_idx];
-                if (!edge.is_variable_length && edge.label_expr && edge.label_expr->kind == LabelExprKind::LITERAL) {
+                // Only collapse a totally-unconstrained edge: collapse deletes one edge, which would
+                // otherwise silently drop its predicates or leave its bound variable unbound.
+                bool edge_unconstrained = edge.variable.empty() && edge.properties.empty() &&
+                    edge.property_filters.empty() && !edge.where_expr;
+                if (!edge.is_variable_length && edge_unconstrained &&
+                    edge.label_expr && edge.label_expr->kind == LabelExprKind::LITERAL) {
                     std::string rel_type = edge.label_expr->name;
                     if (GqlVirtualCatalog::local().has_relationship_algebraic_property(rel_type, "antisymmetric")) {
                         std::string src = match.pattern.nodes[e_idx].variable;
@@ -163,6 +182,16 @@ void AntisymmetricLoopCollapser::antisymmetric_loop_pass(GqlQuery& query) {
                 const auto& e1 = refs[i];
                 const auto& e2 = refs[j];
                 if (e1.rel_type == e2.rel_type && e1.src == e2.tgt && e1.tgt == e2.src) {
+                    // An antisymmetric 2-cycle forces src == tgt (a self-loop). If the relation is
+                    // also irreflexive, that self-loop is impossible, so the query matches nothing.
+                    // (The irreflexive pruner runs before this pass and cannot see the folded loop.)
+                    bool rel_reflexive = GqlVirtualCatalog::local().has_relationship_algebraic_property(e1.rel_type, "reflexive");
+                    bool rel_irreflexive = GqlVirtualCatalog::local().has_relationship_algebraic_property(e1.rel_type, "irreflexive");
+                    if (rel_irreflexive && !rel_reflexive) {
+                        query.no_op = true;
+                        return;
+                    }
+
                     std::string keep_var = e1.src;
                     std::string prune_var = e1.tgt;
 

--- a/test/gql/optimizer/AlglibOptimizerTests.cpp
+++ b/test/gql/optimizer/AlglibOptimizerTests.cpp
@@ -147,3 +147,46 @@ TEST_CASE("GQL Optimizer Phase 26: Equivalence Class Coalescing", "[gql_optimize
     REQUIRE(match.pattern.edges[0].min_hops == 1);
     REQUIRE(match.pattern.edges[0].max_hops == 1);
 }
+
+// Task 001: the antisymmetric collapser must preserve labels/constraints/bound edge variables and
+// detect the irreflexive contradiction, while still collapsing the unconstrained case.
+TEST_CASE("GQL Optimizer Phase 25: collapser preserves constraints", "[gql_optimizer][alglib][task001]") {
+    GqlVirtualCatalog::local().clear();
+
+    SECTION("a labeled single-node match is not pruned away") {
+        auto q = GqlParser::parse("MATCH (x:Person) MATCH (x)-[:KNOWS]->(y) RETURN x, y");
+        GqlOptimizer::optimize(q);
+        REQUIRE(q.matches.size() == 2);
+    }
+
+    SECTION("labels survive an antisymmetric+reflexive collapse (AND, not dropped)") {
+        GqlVirtualCatalog::local().set_relationship_algebraic_properties("po", {"antisymmetric", "reflexive"});
+        auto q = GqlParser::parse("MATCH (a:A)-[:po]->(b:B)-[:po]->(a) RETURN a");
+        GqlOptimizer::optimize(q);
+        REQUIRE(q.matches.size() == 1);
+        REQUIRE(q.matches[0].pattern.nodes[0].label_expr != nullptr);
+        REQUIRE(q.matches[0].pattern.nodes[0].label_expr->kind == LabelExprKind::AND);
+    }
+
+    SECTION("a collapse that would drop a bound edge variable is refused") {
+        GqlVirtualCatalog::local().set_relationship_algebraic_properties("po", {"antisymmetric"});
+        auto q = GqlParser::parse("MATCH (a)-[r:po]->(b)-[r2:po]->(a) RETURN a, r, r2");
+        GqlOptimizer::optimize(q);
+        REQUIRE(q.matches[0].pattern.edges.size() == 2);
+    }
+
+    SECTION("an antisymmetric + irreflexive 2-cycle is a contradiction (no_op)") {
+        GqlVirtualCatalog::local().set_relationship_algebraic_properties("po", {"antisymmetric", "irreflexive"});
+        auto q = GqlParser::parse("MATCH (a)-[:po]->(b)-[:po]->(a) RETURN a");
+        GqlOptimizer::optimize(q);
+        REQUIRE(q.no_op == true);
+    }
+
+    SECTION("positive control: an unconstrained antisymmetric 2-cycle still collapses") {
+        GqlVirtualCatalog::local().set_relationship_algebraic_properties("po", {"antisymmetric"});
+        auto q = GqlParser::parse("MATCH (a)-[:po]->(b)-[:po]->(a) RETURN a, b");
+        GqlOptimizer::optimize(q);
+        REQUIRE(q.matches.size() == 1);
+        REQUIRE(q.matches[0].pattern.edges.size() == 1);
+    }
+}


### PR DESCRIPTION
The antisymmetric-loop collapser silently produced wrong results (no algebraic traits required for the first bug -- it runs for every SINGLE query):

- `merge_pattern_nodes` merged properties/filters/where but **dropped the source node label**; now combines labels with AND.
- `prune_redundant_single_node_matches` (run unconditionally) pruned a single-node match by variable without checking its label, so `MATCH (x:Person) MATCH (x)-[..]` lost `:Person`; now skips matches carrying a label.
- the collapse now only fires for a totally-unconstrained edge (no variable/properties/filters/where), so it can no longer drop edge predicates or leave a bound edge variable unbound.
- an antisymmetric 2-cycle on an also-irreflexive relation folds to an impossible self-loop; the collapser now marks the query `no_op` (the irreflexive pruner runs earlier and cannot see the fold).

## Verification
Red->green on the box: 4 failing assertions on the original (pruned labeled node, dropped merged label, collapsed an edge-variable pattern, missed the irreflexive contradiction); all pass with the fix; a positive control confirms the unconstrained case still collapses.

## Deferred (see notes)
TRAIL row-multiplicity under DIFFERENT_EDGES (conflicts with the existing Phase 25 test -- needs a semantics decision) and `rewrite_expr_vars` completeness for SIZE_OP/IS_NULL_CHECK + MatchStatement scalar vars.