### PR TITLE
fix(gql): LIMIT n returns fewer than n rows when a residual filter survives

### DIFF
--- a/src/gql/GqlExecutor.cpp
+++ b/src/gql/GqlExecutor.cpp
@@ -454,9 +454,27 @@ static seastar::future<QueryResult> execute_query_internal(ragedb::Graph& graph,
         }
     }
 
-    // Determine if we can push limit evaluation directly into the traversal
+    // Determine if we can push limit evaluation directly into the traversal. Pushing the LIMIT as
+    // the physical scan bound is only sound when every remaining predicate is applied INSIDE the
+    // scan; if any predicate is evaluated after the scan (a residual WHERE, a multi-label pattern
+    // post-filtered, or edge predicates post-filtered on the relationship-index path), scanning
+    // exactly `limit` rows under-returns. In those cases scan with the default bound and truncate.
+    bool residual_post_scan_filter = query_ptr->where_expr != nullptr;
+    for (const auto& m : query_ptr->matches) {
+        for (const auto& node : m.pattern.nodes) {
+            if (node.where_expr) residual_post_scan_filter = true;
+            if (node.label_expr && node.label_expr->kind != LabelExprKind::LITERAL) residual_post_scan_filter = true;
+        }
+        for (const auto& edge : m.pattern.edges) {
+            if (edge.where_expr) residual_post_scan_filter = true;
+            if (edge.label_expr && edge.label_expr->kind != LabelExprKind::LITERAL) residual_post_scan_filter = true;
+            if (!edge.properties.empty() || !edge.property_filters.empty()) residual_post_scan_filter = true;
+        }
+    }
+
     size_t limit_val = 0;
-    if (query_ptr->limit.has_value() && query_ptr->order_by.empty() && !query_contains_aggregates) {
+    if (query_ptr->limit.has_value() && query_ptr->order_by.empty() &&
+        !query_contains_aggregates && !residual_post_scan_filter) {
         limit_val = *query_ptr->limit;
     }
 

--- a/src/gql/GqlExecutor.cpp
+++ b/src/gql/GqlExecutor.cpp
@@ -157,6 +157,110 @@ struct GqlRowOuterVarsLess {
  * @param query_ptr Shared pointer to the GQL query.
  * @return A future resolving to a QueryResult containing columns and values.
  */
+/**
+ * @brief A plan for answering a pure COUNT over a single node pattern from the shard count
+ *        indexes, without materializing any Node objects.
+ *
+ * This is the fast path for queries shaped like `MATCH (n:Label) RETURN count(n)` (optionally with
+ * a single property filter). Counting by materializing every node OOMs on large labels, so when a
+ * query matches this exact shape we answer it directly with AllNodesCountPeered / FindNodeCountPeered.
+ * Anything more complex falls back to the normal executor.
+ */
+struct SimpleNodeCountPlan {
+    bool has_label = false;
+    std::string label;
+    bool has_filter = false;
+    std::string filter_property;
+    Operation filter_op = Operation::EQ;
+    property_type_t filter_value;
+    std::string column_name;
+    uint64_t multiplier = 1;
+};
+
+/**
+ * @brief Detect whether a query is a pure COUNT over a single node pattern and, if so, populate a
+ *        SimpleNodeCountPlan. Returns false (fall back to the normal executor) for any shape that
+ *        cannot be answered by a single count-index lookup.
+ */
+static bool try_plan_simple_node_count(const GqlQuery& q, SimpleNodeCountPlan& out) {
+    if (q.kind != QueryKind::SINGLE) return false;
+    if (q.explain || q.profile) return false;      // keep plan/profile output on the normal path
+    if (!q.writes.empty()) return false;
+    if (q.where_expr) return false;
+    if (q.has_unnested_subquery) return false;
+    if (q.distinct) return false;
+    if (q.limit.has_value()) return false;
+    if (!q.order_by.empty()) return false;
+    if (q.matches.size() != 1) return false;
+    if (q.returns.size() != 1) return false;
+
+    const auto& item = q.returns[0];
+    if (!item.expr || item.expr->kind != ExpressionKind::AGGREGATION) return false;
+    const auto* ae = static_cast<const AggregateExpr*>(item.expr.get());
+    if (ae->fn_kind != AggregateKind::COUNT) return false;
+
+    const auto& m = q.matches[0];
+    if (m.is_optional) return false;
+    if (m.shortest_path_kind != ShortestPathKind::NONE) return false;
+    if (m.is_khop) return false;
+    if (!m.path_variable.empty()) return false;
+    if (m.limit.has_value()) return false;
+    if (!m.pattern.edges.empty()) return false;
+    if (m.pattern.nodes.size() != 1) return false;
+
+    const auto& node = m.pattern.nodes[0];
+    if (node.where_expr) return false;
+
+    // The count target must be count(*) or count(<the pattern node's variable>). For a single
+    // non-optional node every matched row binds a distinct node, so count(n) == row count.
+    if (ae->expr) {
+        if (ae->expr->kind != ExpressionKind::VARIABLE) return false;
+        const auto* ve = static_cast<const VariableExpr*>(ae->expr.get());
+        if (node.variable.empty() || ve->name != node.variable) return false;
+    }
+
+    // Only a single literal label (or no label) can be answered by the count endpoints;
+    // AND/OR/NOT/WILDCARD label expressions fall back.
+    if (node.label_expr) {
+        if (node.label_expr->kind != LabelExprKind::LITERAL) return false;
+        out.has_label = true;
+        out.label = node.label_expr->name;
+    }
+
+    // Zero filters -> count all (of the label). Exactly one filter (with a label) -> FindNodeCount.
+    // More than one filter has no single count endpoint, so fall back.
+    size_t filter_count = node.properties.size() + node.property_filters.size();
+    if (filter_count > 1) return false;
+    if (filter_count == 1) {
+        if (!out.has_label) return false;  // FindNodeCountPeered requires a node type
+        out.has_filter = true;
+        if (!node.properties.empty()) {
+            const auto& kv = *node.properties.begin();
+            out.filter_property = kv.first;
+            out.filter_op = Operation::EQ;
+            out.filter_value = kv.second;
+        } else {
+            const auto& f = node.property_filters[0];
+            out.filter_property = f.property;
+            out.filter_op = f.op;
+            out.filter_value = f.value;
+        }
+    }
+
+    // Column name mirrors the key derivation used elsewhere for RETURN items.
+    if (item.alias) {
+        out.column_name = *item.alias;
+    } else if (!ae->expr) {
+        out.column_name = "count(*)";
+    } else {
+        const auto* ve = static_cast<const VariableExpr*>(ae->expr.get());
+        out.column_name = "count(" + ve->name + ")";
+    }
+
+    out.multiplier = q.count_multiplication_factor;
+    return true;
+}
+
 static seastar::future<QueryResult> execute_query_internal(ragedb::Graph& graph, std::shared_ptr<GqlQuery> query_ptr) {
     if (query_ptr->no_op) {
         QueryResult query_res;
@@ -306,6 +410,31 @@ static seastar::future<QueryResult> execute_query_internal(ragedb::Graph& graph,
                 return combined_res;
             });
         });
+    }
+
+    // Fast path: a pure COUNT over a single node pattern is answered directly from the shard count
+    // indexes, without materializing Node objects -- otherwise counting a large label (e.g.
+    // count(Comment) over millions of rows) exhausts memory.
+    {
+        SimpleNodeCountPlan cplan;
+        if (try_plan_simple_node_count(*query_ptr, cplan)) {
+            seastar::future<uint64_t> count_fut = cplan.has_filter
+                ? graph.shard.local().FindNodeCountPeered(cplan.label, cplan.filter_property, cplan.filter_op, cplan.filter_value)
+                : (cplan.has_label ? graph.shard.local().AllNodesCountPeered(cplan.label)
+                                   : graph.shard.local().AllNodesCountPeered());
+            return count_fut.then([cplan](uint64_t c) {
+                int64_t value = static_cast<int64_t>(c);
+                if (cplan.multiplier > 1) {
+                    value *= static_cast<int64_t>(cplan.multiplier);
+                }
+                QueryResult result;
+                result.column_names.push_back(cplan.column_name);
+                std::vector<GqlValue> row;
+                row.push_back(GqlValue(value));
+                result.rows.push_back(std::move(row));
+                return result;
+            });
+        }
     }
 
     // 2. Detect if the query contains aggregate functions (COUNT, SUM, AVG, MIN, MAX)

--- a/src/gql/executor/PathTraverser.cpp
+++ b/src/gql/executor/PathTraverser.cpp
@@ -49,7 +49,6 @@ bool matches_label_expr(const std::string& actual_type, const std::shared_ptr<La
 }
 
 seastar::future<std::vector<Node>> get_start_nodes(ragedb::Graph& graph, const PatternNode& node, size_t limit, const ProjectionPruner& pruner, std::string sort_property, bool sort_ascending, bool sort_by_id) {
-    size_t scan_limit = (limit > 0) ? limit : 100000;
     std::string single_label = "";
     if (node.label_expr && node.label_expr->kind == LabelExprKind::LITERAL) {
         single_label = node.label_expr->name;
@@ -66,49 +65,6 @@ seastar::future<std::vector<Node>> get_start_nodes(ragedb::Graph& graph, const P
     }
     for (const auto& filter : node.property_filters) {
         all_filters.push_back({filter.property, filter.op, filter.value});
-    }
-    
-    seastar::future<std::vector<Node>> fut = seastar::make_ready_future<std::vector<Node>>();
-    if (all_filters.size() > 1 && !single_label.empty()) {
-        std::vector<seastar::future<std::vector<Node>>> futs;
-        for (const auto& filter : all_filters) {
-            futs.push_back(graph.shard.local().FindNodesPeered(single_label, filter.property, filter.op, filter.value, 0, scan_limit));
-        }
-        fut = seastar::when_all_succeed(futs.begin(), futs.end())
-        .then([scan_limit](std::vector<std::vector<Node>> node_lists) {
-            if (node_lists.empty()) return std::vector<Node>{};
-            
-            std::vector<std::vector<uint64_t>> id_lists;
-            for (const auto& list : node_lists) {
-                std::vector<uint64_t> ids;
-                for (const auto& n : list) {
-                    ids.push_back(n.getId());
-                }
-                std::sort(ids.begin(), ids.end());
-                id_lists.push_back(std::move(ids));
-            }
-            
-            std::vector<uint64_t> intersected_ids = leapfrogJoin(id_lists);
-            
-            std::unordered_set<uint64_t> valid_ids(intersected_ids.begin(), intersected_ids.end());
-            std::vector<Node> result;
-            for (const auto& n : node_lists[0]) {
-                if (valid_ids.count(n.getId())) {
-                    result.push_back(n);
-                    if (result.size() >= scan_limit) {
-                        break;
-                    }
-                }
-            }
-            return result;
-        });
-    } else if (all_filters.size() == 1 && !single_label.empty()) {
-        const auto& filter = all_filters[0];
-        fut = graph.shard.local().FindNodesPeered(single_label, filter.property, filter.op, filter.value, 0, scan_limit);
-    } else if (!single_label.empty()) {
-        fut = graph.shard.local().AllNodesPeered(single_label, 0, scan_limit);
-    } else {
-        fut = graph.shard.local().AllNodesPeered(0, scan_limit);
     }
 
     auto sort_nodes = [sort_property, sort_ascending, sort_by_id](std::vector<Node>& list) {
@@ -129,7 +85,60 @@ seastar::future<std::vector<Node>> get_start_nodes(ragedb::Graph& graph, const P
         }
     };
 
-    return fut.then([&graph, degree_opt_info = node.degree_opt_info, var = node.variable, pruner, sort_nodes](std::vector<Node> result_list) mutable {
+    // Determine how many candidate start nodes to scan. An explicit query LIMIT bounds the scan
+    // directly; without one we scan every candidate, deriving the bound from the actual candidate
+    // count so results (and aggregates built on them) are never silently truncated, while the
+    // underlying reserve()/accumulation stays bounded. The multi-filter intersection relies on this
+    // too: each per-filter list is bounded by the label's total node count, so no filter list is
+    // truncated before the leapfrog join.
+    seastar::future<size_t> scan_limit_fut = (limit > 0)
+        ? seastar::make_ready_future<size_t>(limit)
+        : (single_label.empty()
+            ? graph.shard.local().AllNodesCountPeered().then([](uint64_t count) { return static_cast<size_t>(count); })
+            : graph.shard.local().AllNodesCountPeered(single_label).then([](uint64_t count) { return static_cast<size_t>(count); }));
+
+    return scan_limit_fut.then([&graph, single_label, all_filters](size_t scan_limit) {
+        if (all_filters.size() > 1 && !single_label.empty()) {
+            std::vector<seastar::future<std::vector<Node>>> futs;
+            for (const auto& filter : all_filters) {
+                futs.push_back(graph.shard.local().FindNodesPeered(single_label, filter.property, filter.op, filter.value, 0, scan_limit));
+            }
+            return seastar::when_all_succeed(futs.begin(), futs.end())
+            .then([scan_limit](std::vector<std::vector<Node>> node_lists) {
+                if (node_lists.empty()) return std::vector<Node>{};
+
+                std::vector<std::vector<uint64_t>> id_lists;
+                for (const auto& list : node_lists) {
+                    std::vector<uint64_t> ids;
+                    for (const auto& n : list) {
+                        ids.push_back(n.getId());
+                    }
+                    std::sort(ids.begin(), ids.end());
+                    id_lists.push_back(std::move(ids));
+                }
+
+                std::vector<uint64_t> intersected_ids = leapfrogJoin(id_lists);
+
+                std::unordered_set<uint64_t> valid_ids(intersected_ids.begin(), intersected_ids.end());
+                std::vector<Node> result;
+                for (const auto& n : node_lists[0]) {
+                    if (valid_ids.count(n.getId())) {
+                        result.push_back(n);
+                        if (result.size() >= scan_limit) {
+                            break;
+                        }
+                    }
+                }
+                return result;
+            });
+        } else if (all_filters.size() == 1 && !single_label.empty()) {
+            const auto& filter = all_filters[0];
+            return graph.shard.local().FindNodesPeered(single_label, filter.property, filter.op, filter.value, 0, scan_limit);
+        } else if (!single_label.empty()) {
+            return graph.shard.local().AllNodesPeered(single_label, 0, scan_limit);
+        }
+        return graph.shard.local().AllNodesPeered(0, scan_limit);
+    }).then([&graph, degree_opt_info = node.degree_opt_info, var = node.variable, pruner, sort_nodes](std::vector<Node> result_list) mutable {
         if (degree_opt_info.empty()) {
             sort_nodes(result_list);
             if (pruner.should_prune(var)) {
@@ -704,7 +713,6 @@ static seastar::future<std::vector<GqlRow>> traverse_from_relationship_index(
     const ProjectionPruner& pruner,
     PathMode path_mode
 ) {
-    size_t scan_limit = (limit > 0) ? limit : 100000;
     const auto& edge = prep_pattern.edges[0];
     std::string single_label = "";
     if (edge.label_expr && edge.label_expr->kind == LabelExprKind::LITERAL) {
@@ -740,8 +748,16 @@ static seastar::future<std::vector<GqlRow>> traverse_from_relationship_index(
         return seastar::make_ready_future<std::vector<GqlRow>>();
     }
 
-    return graph.shard.local().FindRelationshipsPeered(single_label, indexed_prop, indexed_op, indexed_val, 0, scan_limit)
-    .then([&graph, prep_pattern, base_row, limit, pruner, path_mode](std::vector<Relationship> rels) {
+    // Without an explicit LIMIT, scan every matching relationship. The bound comes from the actual
+    // match count so results and aggregates are never silently truncated while the underlying
+    // reserve()/accumulation stays bounded.
+    seastar::future<size_t> scan_limit_fut = (limit > 0)
+        ? seastar::make_ready_future<size_t>(limit)
+        : graph.shard.local().FindRelationshipCountPeered(single_label, indexed_prop, indexed_op, indexed_val).then([](uint64_t count) { return static_cast<size_t>(count); });
+
+    return scan_limit_fut.then([&graph, single_label, indexed_prop, indexed_op, indexed_val](size_t scan_limit) {
+        return graph.shard.local().FindRelationshipsPeered(single_label, indexed_prop, indexed_op, indexed_val, 0, scan_limit);
+    }).then([&graph, prep_pattern, base_row, limit, pruner, path_mode](std::vector<Relationship> rels) {
         const auto& pattern_edge = prep_pattern.edges[0];
         
         std::vector<Relationship> matched_rels;

--- a/src/gql/optimizer/LimitPushdownOptimizer.cpp
+++ b/src/gql/optimizer/LimitPushdownOptimizer.cpp
@@ -81,6 +81,22 @@ void LimitPushdownOptimizer::limit_pushdown_pass(GqlQuery& query) {
 
     if (query.matches.empty()) return;
 
+    // Do not push the LIMIT into the scan when a predicate is evaluated AFTER the scan (a residual
+    // query/node WHERE, a multi-label pattern, or edge predicates on the relationship-index path):
+    // scanning exactly `limit` rows would under-return. Leave the LIMIT to post-filter truncation.
+    if (query.where_expr) return;
+    for (const auto& m : query.matches) {
+        for (const auto& node : m.pattern.nodes) {
+            if (node.where_expr) return;
+            if (node.label_expr && node.label_expr->kind != LabelExprKind::LITERAL) return;
+        }
+        for (const auto& edge : m.pattern.edges) {
+            if (edge.where_expr) return;
+            if (edge.label_expr && edge.label_expr->kind != LabelExprKind::LITERAL) return;
+            if (!edge.properties.empty() || !edge.property_filters.empty()) return;
+        }
+    }
+
     if (query.matches.size() == 1) {
         query.matches[0].limit = query.limit;
         return;

--- a/test/gql/GqlExecutorReadTests.cpp
+++ b/test/gql/GqlExecutorReadTests.cpp
@@ -398,14 +398,24 @@ TEST_CASE("GQL LIMIT with a residual WHERE returns the full LIMIT", "[gql_execut
             "{\"name\": \"hi" + std::to_string(i) + "\", \"age\": 50}").get();
     }
 
+    auto count_rows = [](const std::string& r) {
+        size_t c = 0, pos = 0;
+        while ((pos = r.find("\"name\":", pos)) != std::string::npos) { c++; pos += 7; }
+        return c;
+    };
+
+    // Sanity: without a LIMIT the residual predicate must match all 5 (isolates query/data issues).
+    std::string res_nolimit = GqlExecutor::execute(graph,
+        std::string("MATCH (n:Person) WHERE n.age > 25 OR n.name = 'zzz' RETURN n.name AS name")).get();
+    INFO("no-limit result: " << res_nolimit);
+    REQUIRE(count_rows(res_nolimit) == 5);
+
     // The OR keeps the predicate residual (not pushed into the scan). With a pushed LIMIT the scan
     // stops at the first 5 (non-matching) rows and under-returns; the fix scans all then truncates.
-    std::string query = "MATCH (n:Person) WHERE n.age > 25 OR n.name = 'zzz' RETURN n.name AS name LIMIT 5";
-    std::string res = GqlExecutor::execute(graph, query).get();
-
-    size_t count = 0, pos = 0;
-    while ((pos = res.find("\"name\":", pos)) != std::string::npos) { count++; pos += 7; }
-    REQUIRE(count == 5);
+    std::string res = GqlExecutor::execute(graph,
+        std::string("MATCH (n:Person) WHERE n.age > 25 OR n.name = 'zzz' RETURN n.name AS name LIMIT 5")).get();
+    INFO("limit-5 result: " << res);
+    REQUIRE(count_rows(res) == 5);
 
     graph.Stop().get();
 }

--- a/test/gql/GqlExecutorReadTests.cpp
+++ b/test/gql/GqlExecutorReadTests.cpp
@@ -378,3 +378,34 @@ TEST_CASE("GQL Execution Read Tests", "[gql_executor_read]") {
 
     guard.stop();
 }
+
+TEST_CASE("GQL LIMIT with a residual WHERE returns the full LIMIT", "[gql_executor_read][task009]") {
+    auto graph = Graph("gql_limit_pushdown_test");
+    graph.Start().get();
+    graph.Clear();
+
+    graph.shard.local().NodeTypeInsertPeered("Person").get();
+    graph.shard.local().NodePropertyTypeAddPeered("Person", "name", "string").get();
+    graph.shard.local().NodePropertyTypeAddPeered("Person", "age", "integer").get();
+
+    // 15 non-matching (age 10) added first (lower ids -> scanned first), then 5 matching (age 50).
+    for (int i = 0; i < 15; ++i) {
+        graph.shard.local().NodeAddPeered("Person", "lo" + std::to_string(i),
+            "{\"name\": \"lo" + std::to_string(i) + "\", \"age\": 10}").get();
+    }
+    for (int i = 0; i < 5; ++i) {
+        graph.shard.local().NodeAddPeered("Person", "hi" + std::to_string(i),
+            "{\"name\": \"hi" + std::to_string(i) + "\", \"age\": 50}").get();
+    }
+
+    // The OR keeps the predicate residual (not pushed into the scan). With a pushed LIMIT the scan
+    // stops at the first 5 (non-matching) rows and under-returns; the fix scans all then truncates.
+    std::string query = "MATCH (n:Person) WHERE n.age > 25 OR n.name = 'zzz' RETURN n.name AS name LIMIT 5";
+    std::string res = GqlExecutor::execute(graph, query).get();
+
+    size_t count = 0, pos = 0;
+    while ((pos = res.find("\"name\":", pos)) != std::string::npos) { count++; pos += 7; }
+    REQUIRE(count == 5);
+
+    graph.Stop().get();
+}


### PR DESCRIPTION
> Stacked on #45 (scan-cap removal).

Pushing the query `LIMIT` as the physical scan bound under-returns whenever a predicate is evaluated AFTER the scan: a residual query/node `WHERE`, a multi-label pattern `(n:A|B)`, or edge predicates post-filtered on the relationship-index path. `MATCH (n:Person) WHERE <non-pushable> RETURN n LIMIT 10` scanned 10, filtered, and returned < 10.

## Root cause / change

Two pushdown sites had to be guarded:
- `LimitPushdownOptimizer::limit_pushdown_pass` set `matches[0].limit = query.limit` unconditionally (the per-match scan limit).
- `execute_query_internal` set `limit_val` from the query LIMIT.

Both now skip pushdown when a residual post-scan filter exists; the LIMIT falls to post-filter truncation (with the scan cap removed, the scan is complete, so truncation is correct).

## Verification

Red->green on the box: a query whose first-scanned rows all fail a residual `OR` predicate returns `[]` under the original pushdown and the full `LIMIT` after the fix; a no-LIMIT control confirms 5 rows match either way.

Note: conservatively skips pushdown for any edge predicate (may over-scan some indexed-edge queries -- a perf, not correctness, tradeoff).