### PR TITLE
fix(gql): bound endpoint enumeration in the transitive fast path (no OOM on unlabeled endpoints)

### DIFF
--- a/src/gql/GqlExecutor.cpp
+++ b/src/gql/GqlExecutor.cpp
@@ -44,6 +44,7 @@
 #include <cstdlib>
 #include <chrono>
 #include <seastar/core/when_all.hh>
+#include <seastar/core/loop.hh>
 
 namespace ragedb::gql {
 
@@ -261,6 +262,344 @@ static bool try_plan_simple_node_count(const GqlQuery& q, SimpleNodeCountPlan& o
     return true;
 }
 
+/**
+ * @brief Derive the output column name for a RETURN item (mirrors the no-op / aggregate paths).
+ */
+static std::string return_item_column_name(const ReturnItem& item, size_t index) {
+    if (item.alias) return *item.alias;
+    if (item.expr->kind == ExpressionKind::PROPERTY_LOOKUP) {
+        auto* pl = static_cast<const PropertyLookupExpr*>(item.expr.get());
+        return pl->variable + "." + pl->property;
+    }
+    if (item.expr->kind == ExpressionKind::VARIABLE) {
+        return static_cast<const VariableExpr*>(item.expr.get())->name;
+    }
+    if (item.expr->kind == ExpressionKind::AGGREGATION) {
+        auto* ae = static_cast<const AggregateExpr*>(item.expr.get());
+        std::string fn = ae->fn_kind == AggregateKind::COUNT ? "count"
+            : ae->fn_kind == AggregateKind::SUM ? "sum"
+            : ae->fn_kind == AggregateKind::AVG ? "avg"
+            : ae->fn_kind == AggregateKind::MIN ? "min" : "max";
+        if (!ae->expr) return fn + "(*)";
+        if (ae->expr->kind == ExpressionKind::PROPERTY_LOOKUP) {
+            auto* pl = static_cast<const PropertyLookupExpr*>(ae->expr.get());
+            return fn + "(" + pl->variable + "." + pl->property + ")";
+        }
+        if (ae->expr->kind == ExpressionKind::VARIABLE) {
+            return fn + "(" + static_cast<const VariableExpr*>(ae->expr.get())->name + ")";
+        }
+        return fn + "(expr)";
+    }
+    return "column_" + std::to_string(index);
+}
+
+/**
+ * @brief Plan for a group-anchored streaming aggregate over a single-edge expansion.
+ *
+ * Answers queries shaped like `MATCH (a:AL)-[:R]->(b:BL) RETURN b.key, count(a) ...` by iterating
+ * the group-side (b) nodes and folding each one's R-neighbours (a) into per-group accumulators, so
+ * peak memory is O(#groups + one node's degree) instead of O(#expansion rows). This avoids the OOM
+ * from materialising the whole (a,b) expansion just to aggregate it. Any shape not cleanly covered
+ * returns false and falls back to the normal (materialising) executor.
+ */
+struct EdgeAggPlan {
+    const PatternNode* group_node = nullptr;
+    const PatternNode* agg_node = nullptr;
+    std::string group_var;
+    std::string agg_var;
+    std::string agg_label;            // literal label of the aggregated node ("" = any)
+    std::string rel_type;
+    Direction dir = Direction::BOTH;  // from group node toward aggregated node
+    std::vector<const Expression*> grouping_keys;
+    std::vector<const AggregateExpr*> aggs;
+    uint64_t multiplier = 1;
+};
+
+static bool node_label_literal(const PatternNode& n, std::string& out_label) {
+    if (!n.label_expr) { out_label = ""; return true; }
+    if (n.label_expr->kind == LabelExprKind::LITERAL) { out_label = n.label_expr->name; return true; }
+    return false;
+}
+
+static bool plan_streaming_edge_aggregate(const GqlQuery& q, EdgeAggPlan& out) {
+    if (q.kind != QueryKind::SINGLE) return false;
+    if (q.explain || q.profile) return false;
+    if (!q.writes.empty()) return false;
+    if (q.where_expr) return false;
+    if (q.has_unnested_subquery) return false;
+    if (q.distinct) return false;
+    if (q.matches.size() != 1) return false;
+
+    const auto& m = q.matches[0];
+    if (m.is_optional) return false;
+    if (m.shortest_path_kind != ShortestPathKind::NONE) return false;
+    if (m.is_khop) return false;
+    if (!m.path_variable.empty()) return false;
+    if (m.limit.has_value()) return false;
+    if (m.pattern.nodes.size() != 2 || m.pattern.edges.size() != 1) return false;
+
+    const auto& edge = m.pattern.edges[0];
+    if (edge.is_variable_length) return false;
+    if (edge.where_expr) return false;
+    if (!edge.properties.empty() || !edge.property_filters.empty()) return false;
+    if (!edge.label_expr || edge.label_expr->kind != LabelExprKind::LITERAL) return false;
+    out.rel_type = edge.label_expr->name;
+
+    for (const auto& item : q.returns) find_aggregates(item.expr.get(), out.aggs);
+    for (const auto& spec : q.order_by) find_aggregates(spec.expr.get(), out.aggs);
+    if (out.aggs.empty()) return false;
+
+    // Aggregates must be count(*) or over a single variable / one of its properties.
+    std::string agg_var;
+    for (const auto* agg : out.aggs) {
+        if (!agg->expr) continue;  // count(*)
+        std::string v;
+        if (agg->expr->kind == ExpressionKind::VARIABLE) v = static_cast<const VariableExpr*>(agg->expr.get())->name;
+        else if (agg->expr->kind == ExpressionKind::PROPERTY_LOOKUP) v = static_cast<const PropertyLookupExpr*>(agg->expr.get())->variable;
+        else return false;
+        if (v.empty()) return false;
+        if (agg_var.empty()) agg_var = v;
+        else if (agg_var != v) return false;  // aggregates span two variables
+    }
+
+    const auto& n0 = m.pattern.nodes[0];
+    const auto& n1 = m.pattern.nodes[1];
+    if (n0.variable.empty() || n1.variable.empty()) return false;
+
+    const PatternNode* group_node = nullptr;
+    const PatternNode* agg_node = nullptr;
+    if (!agg_var.empty()) {
+        if (agg_var == n0.variable) { agg_node = &n0; group_node = &n1; }
+        else if (agg_var == n1.variable) { agg_node = &n1; group_node = &n0; }
+        else return false;
+    }
+
+    // Grouping keys: the non-aggregate RETURN items; must reference a single variable.
+    std::set<std::string> nonagg_vars;
+    for (const auto& item : q.returns) {
+        if (has_aggregates(item.expr.get())) continue;
+        std::string v;
+        if (item.expr->kind == ExpressionKind::VARIABLE) v = static_cast<const VariableExpr*>(item.expr.get())->name;
+        else if (item.expr->kind == ExpressionKind::PROPERTY_LOOKUP) v = static_cast<const PropertyLookupExpr*>(item.expr.get())->variable;
+        else return false;
+        if (v.empty()) return false;
+        nonagg_vars.insert(v);
+        out.grouping_keys.push_back(item.expr.get());
+    }
+    if (nonagg_vars.size() > 1) return false;
+
+    if (!group_node) {
+        // pure count(*): choose the group node from the grouping keys, else default to n1.
+        if (!nonagg_vars.empty()) {
+            const std::string& gv = *nonagg_vars.begin();
+            if (gv == n0.variable) { group_node = &n0; agg_node = &n1; }
+            else if (gv == n1.variable) { group_node = &n1; agg_node = &n0; }
+            else return false;
+        } else {
+            group_node = &n1; agg_node = &n0;
+        }
+    }
+    if (!nonagg_vars.empty() && *nonagg_vars.begin() != group_node->variable) return false;
+
+    std::string group_label, agg_label;
+    if (!node_label_literal(*group_node, group_label)) return false;
+    if (!node_label_literal(*agg_node, agg_label)) return false;
+    if (!group_node->properties.empty() || !group_node->property_filters.empty() || group_node->where_expr) return false;
+    if (!agg_node->properties.empty() || !agg_node->property_filters.empty() || agg_node->where_expr) return false;
+
+    // Direction from group node toward aggregated node. RIGHT means nodes[0]->nodes[1].
+    bool group_is_n0 = (group_node == &n0);
+    if (edge.direction == EdgeDirection::ANY) out.dir = Direction::BOTH;
+    else if (edge.direction == EdgeDirection::RIGHT) out.dir = group_is_n0 ? Direction::OUT : Direction::IN;
+    else out.dir = group_is_n0 ? Direction::IN : Direction::OUT;
+
+    out.group_node = group_node;
+    out.agg_node = agg_node;
+    out.group_var = group_node->variable;
+    out.agg_var = agg_node->variable;
+    out.agg_label = agg_label;
+    out.multiplier = q.count_multiplication_factor;
+    return true;
+}
+
+/**
+ * @brief Incremental accumulator for one aggregate over one group -- mirrors the batch fold in the
+ *        normal aggregate path so results are byte-for-byte identical.
+ */
+struct EdgeAggAccumulator {
+    AggregateKind kind;
+    const Expression* expr;  // nullptr for count(*)
+    int64_t count = 0;
+    int64_t sum_int = 0;
+    double sum_double = 0.0;
+    bool has_double = false;
+    int64_t val_count = 0;
+    GqlValue extreme;
+    bool extreme_set = false;
+
+    void add(const GqlRow& row) {
+        if (kind == AggregateKind::COUNT) {
+            if (!expr) { count++; return; }
+            if (evaluate_expression(row, expr).type != GqlValue::NIL) count++;
+            return;
+        }
+        GqlValue v = evaluate_expression(row, expr);
+        if (kind == AggregateKind::SUM || kind == AggregateKind::AVG) {
+            if (v.type == GqlValue::PROPERTY) {
+                if (std::holds_alternative<int64_t>(v.property)) {
+                    if (has_double) sum_double += static_cast<double>(std::get<int64_t>(v.property));
+                    else sum_int += std::get<int64_t>(v.property);
+                    val_count++;
+                } else if (std::holds_alternative<double>(v.property)) {
+                    if (!has_double) { sum_double = static_cast<double>(sum_int); has_double = true; }
+                    sum_double += std::get<double>(v.property);
+                    val_count++;
+                }
+            }
+        } else if (kind == AggregateKind::MIN) {
+            if (v.type != GqlValue::NIL && (!extreme_set || compare_gql_values(v, extreme) < 0)) { extreme = v; extreme_set = true; }
+        } else if (kind == AggregateKind::MAX) {
+            if (v.type != GqlValue::NIL && (!extreme_set || compare_gql_values(v, extreme) > 0)) { extreme = v; extreme_set = true; }
+        }
+    }
+
+    GqlValue finalize(uint64_t multiplier) const {
+        if (kind == AggregateKind::COUNT) {
+            int64_t c = count;
+            if (multiplier > 1) c *= static_cast<int64_t>(multiplier);
+            return GqlValue(c);
+        }
+        if (kind == AggregateKind::SUM) {
+            if (val_count == 0) return GqlValue();
+            return has_double ? GqlValue(sum_double) : GqlValue(sum_int);
+        }
+        if (kind == AggregateKind::AVG) {
+            if (val_count == 0) return GqlValue();
+            return has_double ? GqlValue(sum_double / static_cast<double>(val_count))
+                              : GqlValue(static_cast<double>(sum_int) / static_cast<double>(val_count));
+        }
+        return extreme_set ? extreme : GqlValue();
+    }
+};
+
+struct EdgeAggGroupState {
+    bool initialized = false;
+    GqlRow rep;
+    std::vector<EdgeAggAccumulator> accs;
+};
+
+struct EdgeAggRunState {
+    std::map<std::vector<GqlValue>, EdgeAggGroupState, GqlValueVectorLess> groups;
+};
+
+/**
+ * @brief Execute a group-anchored streaming aggregate (see EdgeAggPlan). Iterates the group-side
+ *        nodes, folds each one's aggregated-side neighbours into per-group accumulators, then
+ *        projects/sorts/limits the (small) group set exactly as the normal aggregate path does.
+ */
+static seastar::future<QueryResult> run_streaming_edge_aggregate(
+        ragedb::Graph& graph, std::shared_ptr<GqlQuery> query_ptr, EdgeAggPlan plan) {
+    auto state = std::make_shared<EdgeAggRunState>();
+    auto plan_ptr = std::make_shared<EdgeAggPlan>(std::move(plan));
+
+    // Keep the group node's properties intact (grouping keys read them); the default pruner would
+    // strip every property.
+    ProjectionPruner group_pruner;
+    group_pruner.whole_objects.insert(plan_ptr->group_var);
+
+    return get_start_nodes(graph, *plan_ptr->group_node, 0, group_pruner)
+    .then([&graph, state, plan_ptr](std::vector<Node> group_nodes) {
+        auto nodes = std::make_shared<std::vector<Node>>(std::move(group_nodes));
+        return seastar::do_for_each(nodes->begin(), nodes->end(),
+            [&graph, state, plan_ptr](Node& g) {
+                uint64_t gid = g.getId();
+                return graph.shard.local().NodeGetNeighborsPeered(gid, plan_ptr->dir, plan_ptr->rel_type)
+                .then([state, plan_ptr, g](std::vector<Node> neighbors) {
+                    const auto& plan = *plan_ptr;
+                    GqlRow rep;
+                    rep.bindings[plan.group_var] = GqlValue(g);
+
+                    bool any = false;
+                    EdgeAggGroupState* gstate = nullptr;
+                    for (auto& n : neighbors) {
+                        if (!plan.agg_label.empty() && n.getType() != plan.agg_label) continue;
+                        if (!any) {
+                            std::vector<GqlValue> key;
+                            for (const auto* gk : plan.grouping_keys) key.push_back(evaluate_expression(rep, gk));
+                            gstate = &state->groups[key];
+                            if (!gstate->initialized) {
+                                gstate->rep = rep;
+                                for (const auto* agg : plan.aggs) gstate->accs.push_back(EdgeAggAccumulator{agg->fn_kind, agg->expr.get()});
+                                gstate->initialized = true;
+                            }
+                            any = true;
+                        }
+                        GqlRow row = rep;
+                        row.bindings[plan.agg_var] = GqlValue(n);
+                        for (auto& acc : gstate->accs) acc.add(row);
+                    }
+                });
+            }
+        ).then([state, plan_ptr, nodes] { (void)nodes; });
+    }).then([query_ptr, state, plan_ptr] {
+        const auto& query = *query_ptr;
+        const auto& plan = *plan_ptr;
+
+        QueryResult result;
+        for (size_t i = 0; i < query.returns.size(); ++i) {
+            result.column_names.push_back(return_item_column_name(query.returns[i], i));
+        }
+
+        // Ungrouped aggregate over an empty expansion still yields one row (e.g. count -> 0).
+        if (state->groups.empty() && plan.grouping_keys.empty()) {
+            EdgeAggGroupState empty_group;
+            empty_group.rep = GqlRow{};
+            for (const auto* agg : plan.aggs) empty_group.accs.push_back(EdgeAggAccumulator{agg->fn_kind, agg->expr.get()});
+            empty_group.initialized = true;
+            state->groups[{}] = std::move(empty_group);
+        }
+
+        struct GroupRow { std::vector<GqlValue> projected; std::vector<GqlValue> sort_keys; };
+        std::vector<GroupRow> rows;
+        for (auto& [key, gstate] : state->groups) {
+            (void)key;
+            std::map<const AggregateExpr*, GqlValue> agg_results;
+            for (size_t i = 0; i < plan.aggs.size(); ++i) {
+                agg_results[plan.aggs[i]] = gstate.accs[i].finalize(plan.multiplier);
+            }
+            GroupRow gr;
+            for (const auto& item : query.returns) {
+                gr.projected.push_back(evaluate_group_expression(gstate.rep, agg_results, item.expr.get()));
+            }
+            for (const auto& spec : query.order_by) {
+                gr.sort_keys.push_back(evaluate_group_expression(gstate.rep, agg_results, spec.expr.get()));
+            }
+            rows.push_back(std::move(gr));
+        }
+
+        if (!query.order_by.empty()) {
+            auto comp = [&query](const GroupRow& a, const GroupRow& b) {
+                for (size_t i = 0; i < query.order_by.size(); ++i) {
+                    int cmp = compare_gql_values(a.sort_keys[i], b.sort_keys[i]);
+                    if (cmp != 0) return query.order_by[i].ascending ? (cmp < 0) : (cmp > 0);
+                }
+                return false;
+            };
+            if (query.limit && *query.limit < rows.size()) {
+                std::partial_sort(rows.begin(), rows.begin() + *query.limit, rows.end(), comp);
+                rows.resize(*query.limit);
+            } else {
+                std::stable_sort(rows.begin(), rows.end(), comp);
+            }
+        } else if (query.limit && *query.limit < rows.size()) {
+            rows.resize(*query.limit);
+        }
+
+        for (auto& gr : rows) result.rows.push_back(std::move(gr.projected));
+        return result;
+    });
+}
+
 static seastar::future<QueryResult> execute_query_internal(ragedb::Graph& graph, std::shared_ptr<GqlQuery> query_ptr) {
     if (query_ptr->no_op) {
         QueryResult query_res;
@@ -434,6 +773,16 @@ static seastar::future<QueryResult> execute_query_internal(ragedb::Graph& graph,
                 result.rows.push_back(std::move(row));
                 return result;
             });
+        }
+    }
+
+    // Fast path: a grouped/ungrouped aggregate over a single-edge expansion is streamed group by
+    // group (see EdgeAggPlan) instead of materialising the whole (a,b) expansion -- otherwise a
+    // large expansion (e.g. count(comment) per person over millions of comments) exhausts memory.
+    {
+        EdgeAggPlan eplan;
+        if (plan_streaming_edge_aggregate(*query_ptr, eplan)) {
+            return run_streaming_edge_aggregate(graph, query_ptr, std::move(eplan));
         }
     }
 

--- a/src/gql/GqlExecutor.cpp
+++ b/src/gql/GqlExecutor.cpp
@@ -157,6 +157,110 @@ struct GqlRowOuterVarsLess {
  * @param query_ptr Shared pointer to the GQL query.
  * @return A future resolving to a QueryResult containing columns and values.
  */
+/**
+ * @brief A plan for answering a pure COUNT over a single node pattern from the shard count
+ *        indexes, without materializing any Node objects.
+ *
+ * This is the fast path for queries shaped like `MATCH (n:Label) RETURN count(n)` (optionally with
+ * a single property filter). Counting by materializing every node OOMs on large labels, so when a
+ * query matches this exact shape we answer it directly with AllNodesCountPeered / FindNodeCountPeered.
+ * Anything more complex falls back to the normal executor.
+ */
+struct SimpleNodeCountPlan {
+    bool has_label = false;
+    std::string label;
+    bool has_filter = false;
+    std::string filter_property;
+    Operation filter_op = Operation::EQ;
+    property_type_t filter_value;
+    std::string column_name;
+    uint64_t multiplier = 1;
+};
+
+/**
+ * @brief Detect whether a query is a pure COUNT over a single node pattern and, if so, populate a
+ *        SimpleNodeCountPlan. Returns false (fall back to the normal executor) for any shape that
+ *        cannot be answered by a single count-index lookup.
+ */
+static bool try_plan_simple_node_count(const GqlQuery& q, SimpleNodeCountPlan& out) {
+    if (q.kind != QueryKind::SINGLE) return false;
+    if (q.explain || q.profile) return false;      // keep plan/profile output on the normal path
+    if (!q.writes.empty()) return false;
+    if (q.where_expr) return false;
+    if (q.has_unnested_subquery) return false;
+    if (q.distinct) return false;
+    if (q.limit.has_value()) return false;
+    if (!q.order_by.empty()) return false;
+    if (q.matches.size() != 1) return false;
+    if (q.returns.size() != 1) return false;
+
+    const auto& item = q.returns[0];
+    if (!item.expr || item.expr->kind != ExpressionKind::AGGREGATION) return false;
+    const auto* ae = static_cast<const AggregateExpr*>(item.expr.get());
+    if (ae->fn_kind != AggregateKind::COUNT) return false;
+
+    const auto& m = q.matches[0];
+    if (m.is_optional) return false;
+    if (m.shortest_path_kind != ShortestPathKind::NONE) return false;
+    if (m.is_khop) return false;
+    if (!m.path_variable.empty()) return false;
+    if (m.limit.has_value()) return false;
+    if (!m.pattern.edges.empty()) return false;
+    if (m.pattern.nodes.size() != 1) return false;
+
+    const auto& node = m.pattern.nodes[0];
+    if (node.where_expr) return false;
+
+    // The count target must be count(*) or count(<the pattern node's variable>). For a single
+    // non-optional node every matched row binds a distinct node, so count(n) == row count.
+    if (ae->expr) {
+        if (ae->expr->kind != ExpressionKind::VARIABLE) return false;
+        const auto* ve = static_cast<const VariableExpr*>(ae->expr.get());
+        if (node.variable.empty() || ve->name != node.variable) return false;
+    }
+
+    // Only a single literal label (or no label) can be answered by the count endpoints;
+    // AND/OR/NOT/WILDCARD label expressions fall back.
+    if (node.label_expr) {
+        if (node.label_expr->kind != LabelExprKind::LITERAL) return false;
+        out.has_label = true;
+        out.label = node.label_expr->name;
+    }
+
+    // Zero filters -> count all (of the label). Exactly one filter (with a label) -> FindNodeCount.
+    // More than one filter has no single count endpoint, so fall back.
+    size_t filter_count = node.properties.size() + node.property_filters.size();
+    if (filter_count > 1) return false;
+    if (filter_count == 1) {
+        if (!out.has_label) return false;  // FindNodeCountPeered requires a node type
+        out.has_filter = true;
+        if (!node.properties.empty()) {
+            const auto& kv = *node.properties.begin();
+            out.filter_property = kv.first;
+            out.filter_op = Operation::EQ;
+            out.filter_value = kv.second;
+        } else {
+            const auto& f = node.property_filters[0];
+            out.filter_property = f.property;
+            out.filter_op = f.op;
+            out.filter_value = f.value;
+        }
+    }
+
+    // Column name mirrors the key derivation used elsewhere for RETURN items.
+    if (item.alias) {
+        out.column_name = *item.alias;
+    } else if (!ae->expr) {
+        out.column_name = "count(*)";
+    } else {
+        const auto* ve = static_cast<const VariableExpr*>(ae->expr.get());
+        out.column_name = "count(" + ve->name + ")";
+    }
+
+    out.multiplier = q.count_multiplication_factor;
+    return true;
+}
+
 static seastar::future<QueryResult> execute_query_internal(ragedb::Graph& graph, std::shared_ptr<GqlQuery> query_ptr) {
     if (query_ptr->no_op) {
         QueryResult query_res;
@@ -306,6 +410,31 @@ static seastar::future<QueryResult> execute_query_internal(ragedb::Graph& graph,
                 return combined_res;
             });
         });
+    }
+
+    // Fast path: a pure COUNT over a single node pattern is answered directly from the shard count
+    // indexes, without materializing Node objects -- otherwise counting a large label (e.g.
+    // count(Comment) over millions of rows) exhausts memory.
+    {
+        SimpleNodeCountPlan cplan;
+        if (try_plan_simple_node_count(*query_ptr, cplan)) {
+            seastar::future<uint64_t> count_fut = cplan.has_filter
+                ? graph.shard.local().FindNodeCountPeered(cplan.label, cplan.filter_property, cplan.filter_op, cplan.filter_value)
+                : (cplan.has_label ? graph.shard.local().AllNodesCountPeered(cplan.label)
+                                   : graph.shard.local().AllNodesCountPeered());
+            return count_fut.then([cplan](uint64_t c) {
+                int64_t value = static_cast<int64_t>(c);
+                if (cplan.multiplier > 1) {
+                    value *= static_cast<int64_t>(cplan.multiplier);
+                }
+                QueryResult result;
+                result.column_names.push_back(cplan.column_name);
+                std::vector<GqlValue> row;
+                row.push_back(GqlValue(value));
+                result.rows.push_back(std::move(row));
+                return result;
+            });
+        }
     }
 
     // 2. Detect if the query contains aggregate functions (COUNT, SUM, AVG, MIN, MAX)

--- a/src/gql/executor/PathTraverser.cpp
+++ b/src/gql/executor/PathTraverser.cpp
@@ -1523,35 +1523,64 @@ seastar::future<std::vector<GqlRow>> traverse_match_statement(ragedb::Graph& gra
             });
         }
 
+        return descendants_fut.then([&graph, stmt, row, start_node_var, end_node_var, pruner](std::map<uint64_t, std::unordered_set<uint64_t>> descendants) {
+        const auto& start_pat = stmt.pattern.nodes[0];
+        const auto& end_pat = stmt.pattern.nodes[1];
+        // An unbound endpoint with no label/property/filter constraint would scan the whole graph via
+        // get_start_nodes. Derive its candidates from the reachability map instead (start side = the
+        // map's keys, end side = the reachable set), bounding memory by the relation's node set rather
+        // than the entire graph. Labeled/constrained endpoints keep get_start_nodes (bounded by label).
+        bool start_unconstrained = !start_pat.label_expr && start_pat.properties.empty() &&
+            start_pat.property_filters.empty() && !start_pat.where_expr;
+        bool end_unconstrained = !end_pat.label_expr && end_pat.properties.empty() &&
+            end_pat.property_filters.empty() && !end_pat.where_expr;
+
         seastar::future<std::vector<Node>> start_nodes_fut = seastar::make_ready_future<std::vector<Node>>();
+        bool start_resolved = false;
         if (!start_node_var.empty()) {
             auto bound_start_it = row.bindings.find(start_node_var);
             if (bound_start_it != row.bindings.end() && bound_start_it->second.type == GqlValue::NODE) {
                 start_nodes_fut = seastar::make_ready_future<std::vector<Node>>(std::vector<Node>{ *bound_start_it->second.node });
+                start_resolved = true;
+            }
+        }
+        if (!start_resolved) {
+            if (start_unconstrained) {
+                std::vector<uint64_t> ids;
+                ids.reserve(descendants.size());
+                for (const auto& kv : descendants) ids.push_back(kv.first);
+                start_nodes_fut = graph.shard.local().NodesGetPeered(ids);
             } else {
                 start_nodes_fut = get_start_nodes(graph, stmt.pattern.nodes[0], 0, pruner);
             }
-        } else {
-            start_nodes_fut = get_start_nodes(graph, stmt.pattern.nodes[0], 0, pruner);
         }
 
         seastar::future<std::vector<Node>> end_nodes_fut = seastar::make_ready_future<std::vector<Node>>();
+        bool end_resolved = false;
         if (!end_node_var.empty()) {
             auto bound_end_it = row.bindings.find(end_node_var);
             if (bound_end_it != row.bindings.end() && bound_end_it->second.type == GqlValue::NODE) {
                 end_nodes_fut = seastar::make_ready_future<std::vector<Node>>(std::vector<Node>{ *bound_end_it->second.node });
+                end_resolved = true;
+            }
+        }
+        if (!end_resolved) {
+            if (end_unconstrained) {
+                std::unordered_set<uint64_t> end_id_set;
+                for (const auto& kv : descendants) {
+                    for (uint64_t d : kv.second) end_id_set.insert(d);
+                }
+                std::vector<uint64_t> ids(end_id_set.begin(), end_id_set.end());
+                end_nodes_fut = graph.shard.local().NodesGetPeered(ids);
             } else {
                 end_nodes_fut = get_start_nodes(graph, stmt.pattern.nodes[1], 0, pruner);
             }
-        } else {
-            end_nodes_fut = get_start_nodes(graph, stmt.pattern.nodes[1], 0, pruner);
         }
 
-        return seastar::when_all_succeed(std::move(descendants_fut), std::move(start_nodes_fut), std::move(end_nodes_fut))
-        .then([&graph, stmt, row, start_node_var, end_node_var](std::tuple<std::map<uint64_t, std::unordered_set<uint64_t>>, std::vector<Node>, std::vector<Node>> results) {
-            auto descendants = std::move(std::get<0>(results));
-            auto start_nodes = std::move(std::get<1>(results));
-            auto end_nodes = std::move(std::get<2>(results));
+        return seastar::when_all_succeed(std::move(start_nodes_fut), std::move(end_nodes_fut))
+        .then([stmt, row, start_node_var, end_node_var, descendants = std::move(descendants)](std::tuple<std::vector<Node>, std::vector<Node>> results) {
+            auto start_nodes = std::move(std::get<0>(results));
+            auto end_nodes = std::move(std::get<1>(results));
 
             std::vector<Node> valid_starts;
             for (const auto& node : start_nodes) {
@@ -1615,6 +1644,7 @@ seastar::future<std::vector<GqlRow>> traverse_match_statement(ragedb::Graph& gra
             }
 
             return out_rows;
+        });
         });
     }
 

--- a/src/gql/executor/PathTraverser.cpp
+++ b/src/gql/executor/PathTraverser.cpp
@@ -49,7 +49,6 @@ bool matches_label_expr(const std::string& actual_type, const std::shared_ptr<La
 }
 
 seastar::future<std::vector<Node>> get_start_nodes(ragedb::Graph& graph, const PatternNode& node, size_t limit, const ProjectionPruner& pruner, std::string sort_property, bool sort_ascending, bool sort_by_id) {
-    size_t scan_limit = (limit > 0) ? limit : 100000;
     std::string single_label = "";
     if (node.label_expr && node.label_expr->kind == LabelExprKind::LITERAL) {
         single_label = node.label_expr->name;
@@ -66,49 +65,6 @@ seastar::future<std::vector<Node>> get_start_nodes(ragedb::Graph& graph, const P
     }
     for (const auto& filter : node.property_filters) {
         all_filters.push_back({filter.property, filter.op, filter.value});
-    }
-    
-    seastar::future<std::vector<Node>> fut = seastar::make_ready_future<std::vector<Node>>();
-    if (all_filters.size() > 1 && !single_label.empty()) {
-        std::vector<seastar::future<std::vector<Node>>> futs;
-        for (const auto& filter : all_filters) {
-            futs.push_back(graph.shard.local().FindNodesPeered(single_label, filter.property, filter.op, filter.value, 0, scan_limit));
-        }
-        fut = seastar::when_all_succeed(futs.begin(), futs.end())
-        .then([scan_limit](std::vector<std::vector<Node>> node_lists) {
-            if (node_lists.empty()) return std::vector<Node>{};
-            
-            std::vector<std::vector<uint64_t>> id_lists;
-            for (const auto& list : node_lists) {
-                std::vector<uint64_t> ids;
-                for (const auto& n : list) {
-                    ids.push_back(n.getId());
-                }
-                std::sort(ids.begin(), ids.end());
-                id_lists.push_back(std::move(ids));
-            }
-            
-            std::vector<uint64_t> intersected_ids = leapfrogJoin(id_lists);
-            
-            std::unordered_set<uint64_t> valid_ids(intersected_ids.begin(), intersected_ids.end());
-            std::vector<Node> result;
-            for (const auto& n : node_lists[0]) {
-                if (valid_ids.count(n.getId())) {
-                    result.push_back(n);
-                    if (result.size() >= scan_limit) {
-                        break;
-                    }
-                }
-            }
-            return result;
-        });
-    } else if (all_filters.size() == 1 && !single_label.empty()) {
-        const auto& filter = all_filters[0];
-        fut = graph.shard.local().FindNodesPeered(single_label, filter.property, filter.op, filter.value, 0, scan_limit);
-    } else if (!single_label.empty()) {
-        fut = graph.shard.local().AllNodesPeered(single_label, 0, scan_limit);
-    } else {
-        fut = graph.shard.local().AllNodesPeered(0, scan_limit);
     }
 
     auto sort_nodes = [sort_property, sort_ascending, sort_by_id](std::vector<Node>& list) {
@@ -129,7 +85,60 @@ seastar::future<std::vector<Node>> get_start_nodes(ragedb::Graph& graph, const P
         }
     };
 
-    return fut.then([&graph, degree_opt_info = node.degree_opt_info, var = node.variable, pruner, sort_nodes](std::vector<Node> result_list) mutable {
+    // Determine how many candidate start nodes to scan. An explicit query LIMIT bounds the scan
+    // directly; without one we scan every candidate, deriving the bound from the actual candidate
+    // count so results (and aggregates built on them) are never silently truncated, while the
+    // underlying reserve()/accumulation stays bounded. The multi-filter intersection relies on this
+    // too: each per-filter list is bounded by the label's total node count, so no filter list is
+    // truncated before the leapfrog join.
+    seastar::future<size_t> scan_limit_fut = (limit > 0)
+        ? seastar::make_ready_future<size_t>(limit)
+        : (single_label.empty()
+            ? graph.shard.local().AllNodesCountPeered().then([](uint64_t count) { return static_cast<size_t>(count); })
+            : graph.shard.local().AllNodesCountPeered(single_label).then([](uint64_t count) { return static_cast<size_t>(count); }));
+
+    return scan_limit_fut.then([&graph, single_label, all_filters](size_t scan_limit) {
+        if (all_filters.size() > 1 && !single_label.empty()) {
+            std::vector<seastar::future<std::vector<Node>>> futs;
+            for (const auto& filter : all_filters) {
+                futs.push_back(graph.shard.local().FindNodesPeered(single_label, filter.property, filter.op, filter.value, 0, scan_limit));
+            }
+            return seastar::when_all_succeed(futs.begin(), futs.end())
+            .then([scan_limit](std::vector<std::vector<Node>> node_lists) {
+                if (node_lists.empty()) return std::vector<Node>{};
+
+                std::vector<std::vector<uint64_t>> id_lists;
+                for (const auto& list : node_lists) {
+                    std::vector<uint64_t> ids;
+                    for (const auto& n : list) {
+                        ids.push_back(n.getId());
+                    }
+                    std::sort(ids.begin(), ids.end());
+                    id_lists.push_back(std::move(ids));
+                }
+
+                std::vector<uint64_t> intersected_ids = leapfrogJoin(id_lists);
+
+                std::unordered_set<uint64_t> valid_ids(intersected_ids.begin(), intersected_ids.end());
+                std::vector<Node> result;
+                for (const auto& n : node_lists[0]) {
+                    if (valid_ids.count(n.getId())) {
+                        result.push_back(n);
+                        if (result.size() >= scan_limit) {
+                            break;
+                        }
+                    }
+                }
+                return result;
+            });
+        } else if (all_filters.size() == 1 && !single_label.empty()) {
+            const auto& filter = all_filters[0];
+            return graph.shard.local().FindNodesPeered(single_label, filter.property, filter.op, filter.value, 0, scan_limit);
+        } else if (!single_label.empty()) {
+            return graph.shard.local().AllNodesPeered(single_label, 0, scan_limit);
+        }
+        return graph.shard.local().AllNodesPeered(0, scan_limit);
+    }).then([&graph, degree_opt_info = node.degree_opt_info, var = node.variable, pruner, sort_nodes](std::vector<Node> result_list) mutable {
         if (degree_opt_info.empty()) {
             sort_nodes(result_list);
             if (pruner.should_prune(var)) {
@@ -704,7 +713,6 @@ static seastar::future<std::vector<GqlRow>> traverse_from_relationship_index(
     const ProjectionPruner& pruner,
     PathMode path_mode
 ) {
-    size_t scan_limit = (limit > 0) ? limit : 100000;
     const auto& edge = prep_pattern.edges[0];
     std::string single_label = "";
     if (edge.label_expr && edge.label_expr->kind == LabelExprKind::LITERAL) {
@@ -740,8 +748,16 @@ static seastar::future<std::vector<GqlRow>> traverse_from_relationship_index(
         return seastar::make_ready_future<std::vector<GqlRow>>();
     }
 
-    return graph.shard.local().FindRelationshipsPeered(single_label, indexed_prop, indexed_op, indexed_val, 0, scan_limit)
-    .then([&graph, prep_pattern, base_row, limit, pruner, path_mode](std::vector<Relationship> rels) {
+    // Without an explicit LIMIT, scan every matching relationship. The bound comes from the actual
+    // match count so results and aggregates are never silently truncated while the underlying
+    // reserve()/accumulation stays bounded.
+    seastar::future<size_t> scan_limit_fut = (limit > 0)
+        ? seastar::make_ready_future<size_t>(limit)
+        : graph.shard.local().FindRelationshipCountPeered(single_label, indexed_prop, indexed_op, indexed_val).then([](uint64_t count) { return static_cast<size_t>(count); });
+
+    return scan_limit_fut.then([&graph, single_label, indexed_prop, indexed_op, indexed_val](size_t scan_limit) {
+        return graph.shard.local().FindRelationshipsPeered(single_label, indexed_prop, indexed_op, indexed_val, 0, scan_limit);
+    }).then([&graph, prep_pattern, base_row, limit, pruner, path_mode](std::vector<Relationship> rels) {
         const auto& pattern_edge = prep_pattern.edges[0];
         
         std::vector<Relationship> matched_rels;

--- a/src/gql/executor/PathTraverser.cpp
+++ b/src/gql/executor/PathTraverser.cpp
@@ -20,6 +20,7 @@
 #include "WccCache.h"
 #include "TransitiveReachabilityCache.h"
 #include <seastar/core/when_all.hh>
+#include <seastar/core/thread.hh>
 #include <seastar/util/later.hh>
 #include <algorithm>
 #include <unordered_set>
@@ -1382,9 +1383,15 @@ seastar::future<std::vector<GqlRow>> traverse_match_statement(ragedb::Graph& gra
         if (WccCache::local().has(rel_type)) {
             partitions_fut = seastar::make_ready_future<std::map<uint64_t, uint64_t>>(WccCache::local().get(rel_type));
         } else {
-            std::map<uint64_t, uint64_t> wcc = graph.shard.local().WeaklyConnectedComponentsPeered(rel_type, "", "", "", "", true, false);
-            WccCache::local().set(rel_type, std::move(wcc));
-            partitions_fut = seastar::make_ready_future<std::map<uint64_t, uint64_t>>(WccCache::local().get(rel_type));
+            // WeaklyConnectedComponentsPeered blocks on cross-shard futures internally (.get0()),
+            // which aborts when run on the reactor thread (the HTTP/GQL path, smp>1). Run it inside a
+            // seastar::thread where waiting is legal, then cache and continue asynchronously.
+            partitions_fut = seastar::async([&graph, rel_type] {
+                return graph.shard.local().WeaklyConnectedComponentsPeered(rel_type, "", "", "", "", true, false);
+            }).then([rel_type](std::map<uint64_t, uint64_t> wcc) {
+                WccCache::local().set(rel_type, std::move(wcc));
+                return WccCache::local().get(rel_type);
+            });
         }
 
         seastar::future<std::vector<Node>> start_nodes_fut = seastar::make_ready_future<std::vector<Node>>();
@@ -1496,16 +1503,24 @@ seastar::future<std::vector<GqlRow>> traverse_match_statement(ragedb::Graph& gra
             rel_type = edge.label_expr->name;
         }
 
-        std::map<uint64_t, std::unordered_set<uint64_t>> descendants;
+        seastar::future<std::map<uint64_t, std::unordered_set<uint64_t>>> descendants_fut =
+            seastar::make_ready_future<std::map<uint64_t, std::unordered_set<uint64_t>>>();
         if (TransitiveReachabilityCache::local().has(rel_type)) {
-            descendants = TransitiveReachabilityCache::local().get(rel_type);
+            descendants_fut = seastar::make_ready_future<std::map<uint64_t, std::unordered_set<uint64_t>>>(TransitiveReachabilityCache::local().get(rel_type));
         } else {
-            std::vector<std::pair<uint64_t, uint64_t>> pairs = graph.shard.local().ReachablePeered(rel_type, "", "", "", "", true, false);
-            for (const auto& p : pairs) {
-                descendants[p.first].insert(p.second);
-            }
-            TransitiveReachabilityCache::local().set(rel_type, std::move(descendants));
-            descendants = TransitiveReachabilityCache::local().get(rel_type);
+            // ReachablePeered blocks on cross-shard futures internally (.get0()), which aborts on the
+            // reactor thread (the HTTP/GQL path, smp>1). Run it inside a seastar::thread where waiting
+            // is legal, then build the descendants index and cache it asynchronously.
+            descendants_fut = seastar::async([&graph, rel_type] {
+                return graph.shard.local().ReachablePeered(rel_type, "", "", "", "", true, false);
+            }).then([rel_type](std::vector<std::pair<uint64_t, uint64_t>> pairs) {
+                std::map<uint64_t, std::unordered_set<uint64_t>> descendants;
+                for (const auto& p : pairs) {
+                    descendants[p.first].insert(p.second);
+                }
+                TransitiveReachabilityCache::local().set(rel_type, std::move(descendants));
+                return TransitiveReachabilityCache::local().get(rel_type);
+            });
         }
 
         seastar::future<std::vector<Node>> start_nodes_fut = seastar::make_ready_future<std::vector<Node>>();
@@ -1532,10 +1547,11 @@ seastar::future<std::vector<GqlRow>> traverse_match_statement(ragedb::Graph& gra
             end_nodes_fut = get_start_nodes(graph, stmt.pattern.nodes[1], 0, pruner);
         }
 
-        return seastar::when_all_succeed(std::move(start_nodes_fut), std::move(end_nodes_fut))
-        .then([&graph, stmt, row, start_node_var, end_node_var, descendants = std::move(descendants)](std::tuple<std::vector<Node>, std::vector<Node>> results) {
-            auto start_nodes = std::move(std::get<0>(results));
-            auto end_nodes = std::move(std::get<1>(results));
+        return seastar::when_all_succeed(std::move(descendants_fut), std::move(start_nodes_fut), std::move(end_nodes_fut))
+        .then([&graph, stmt, row, start_node_var, end_node_var](std::tuple<std::map<uint64_t, std::unordered_set<uint64_t>>, std::vector<Node>, std::vector<Node>> results) {
+            auto descendants = std::move(std::get<0>(results));
+            auto start_nodes = std::move(std::get<1>(results));
+            auto end_nodes = std::move(std::get<2>(results));
 
             std::vector<Node> valid_starts;
             for (const auto& node : start_nodes) {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -65,6 +65,7 @@ add_executable(tests tests.cpp shard/ShardIds.cpp shard/Ids.cpp shard/NodeTypes.
         gql/GqlExecutorPatternTests.cpp
         gql/GqlExecutorWriteTests.cpp
         gql/GqlExecutorAggregationTests.cpp
+        gql/GqlExecutorGroupedExpansionTests.cpp
         gql/GqlExecutorSchemaTests.cpp
         gql/GqlTypecheckerTests.cpp
         gql/GqlQueryCacheTests.cpp

--- a/test/gql/GqlExecutorGroupedExpansionTests.cpp
+++ b/test/gql/GqlExecutorGroupedExpansionTests.cpp
@@ -1,0 +1,136 @@
+/*
+ * Copyright RageDB Contributors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <catch2/catch.hpp>
+#include <Graph.h>
+#include "../../src/gql/GqlParser.h"
+#include "../../src/gql/GqlOptimizer.h"
+#include "../../src/gql/GqlExecutor.h"
+
+using namespace ragedb;
+using namespace ragedb::gql;
+
+/*
+ * Grouped aggregation over a multi-hop expansion -- the shape that OOMs at scale (task 015):
+ *   MATCH (c:Comment)-[:HAS_CREATOR]->(p:Person) RETURN p.name, count(c) ...
+ * The executor flattens the whole (comment, person) expansion before grouping, so at SF1 scale
+ * (~1.7M comments) it exhausts memory. These tests pin the CORRECT small-graph behaviour so a
+ * streaming/factorized aggregate rewrite can be proven not to change results.
+ *
+ * Data: three people, six comments -- Alice authored 3, Bob 2, Carol 1; comment scores are
+ * Alice {1,2,3}, Bob {4,5}, Carol {10}.
+ */
+static void populate_expansion_graph(Graph& graph) {
+    graph.Clear();
+
+    graph.shard.local().NodeTypeInsertPeered("Person").get();
+    graph.shard.local().NodePropertyTypeAddPeered("Person", "name", "string").get();
+    graph.shard.local().NodeTypeInsertPeered("Comment").get();
+    graph.shard.local().NodePropertyTypeAddPeered("Comment", "score", "integer").get();
+    graph.shard.local().RelationshipTypeInsertPeered("HAS_CREATOR").get();
+
+    uint64_t alice = graph.shard.local().NodeAddPeered("Person", "alice", "{\"name\": \"Alice\"}").get();
+    uint64_t bob = graph.shard.local().NodeAddPeered("Person", "bob", "{\"name\": \"Bob\"}").get();
+    uint64_t carol = graph.shard.local().NodeAddPeered("Person", "carol", "{\"name\": \"Carol\"}").get();
+
+    auto add_comment = [&](const std::string& key, int64_t score, uint64_t creator) {
+        uint64_t c = graph.shard.local().NodeAddPeered("Comment", key, "{\"score\": " + std::to_string(score) + "}").get();
+        graph.shard.local().RelationshipAddPeered("HAS_CREATOR", c, creator, "{}").get();
+    };
+    add_comment("a1", 1, alice);
+    add_comment("a2", 2, alice);
+    add_comment("a3", 3, alice);
+    add_comment("b1", 4, bob);
+    add_comment("b2", 5, bob);
+    add_comment("c1", 10, carol);
+}
+
+TEST_CASE("GQL grouped aggregation over expansion: count grouped by creator", "[gql_executor_aggregation][grouped_expansion]") {
+    auto graph = Graph("gql_grouped_expansion_test");
+    graph.Start().get();
+    populate_expansion_graph(graph);
+
+    SECTION("count(c) grouped by person, ordered by count descending") {
+        std::string query = "MATCH (c:Comment)-[:HAS_CREATOR]->(p:Person) RETURN p.name AS name, count(c) AS n ORDER BY count(c) DESC";
+        std::string res = GqlExecutor::execute(graph, GqlParser::parse(query)).get();
+
+        // Every group present with the right count.
+        REQUIRE(res.find("\"name\": \"Alice\", \"n\": 3") != std::string::npos);
+        REQUIRE(res.find("\"name\": \"Bob\", \"n\": 2") != std::string::npos);
+        REQUIRE(res.find("\"name\": \"Carol\", \"n\": 1") != std::string::npos);
+
+        // Ordered by count DESC: Alice(3) before Bob(2) before Carol(1).
+        REQUIRE(res.find("Alice") < res.find("Bob"));
+        REQUIRE(res.find("Bob") < res.find("Carol"));
+    }
+
+    SECTION("count(*) grouped by person") {
+        std::string query = "MATCH (c:Comment)-[:HAS_CREATOR]->(p:Person) RETURN p.name AS name, count(*) AS n ORDER BY p.name ASC";
+        std::string res = GqlExecutor::execute(graph, GqlParser::parse(query)).get();
+        REQUIRE(res.find("\"name\": \"Alice\", \"n\": 3") != std::string::npos);
+        REQUIRE(res.find("\"name\": \"Bob\", \"n\": 2") != std::string::npos);
+        REQUIRE(res.find("\"name\": \"Carol\", \"n\": 1") != std::string::npos);
+    }
+
+    SECTION("top-k: ORDER BY count(c) DESC LIMIT 2 drops the smallest group") {
+        std::string query = "MATCH (c:Comment)-[:HAS_CREATOR]->(p:Person) RETURN p.name AS name, count(c) AS n ORDER BY count(c) DESC LIMIT 2";
+        std::string res = GqlExecutor::execute(graph, GqlParser::parse(query)).get();
+        REQUIRE(res.find("Alice") != std::string::npos);
+        REQUIRE(res.find("Bob") != std::string::npos);
+        REQUIRE(res.find("Carol") == std::string::npos);
+    }
+
+    graph.Stop().get();
+}
+
+TEST_CASE("GQL grouped aggregation over expansion: sum/min/max of an expansion property", "[gql_executor_aggregation][grouped_expansion]") {
+    auto graph = Graph("gql_grouped_expansion_test");
+    graph.Start().get();
+    populate_expansion_graph(graph);
+
+    std::string query = "MATCH (c:Comment)-[:HAS_CREATOR]->(p:Person) RETURN p.name AS name, sum(c.score) AS s, min(c.score) AS mn, max(c.score) AS mx ORDER BY p.name ASC";
+    std::string res = GqlExecutor::execute(graph, GqlParser::parse(query)).get();
+
+    // Alice scores {1,2,3}: sum 6, min 1, max 3.
+    REQUIRE(res.find("\"name\": \"Alice\", \"s\": 6, \"mn\": 1, \"mx\": 3") != std::string::npos);
+    // Bob scores {4,5}: sum 9, min 4, max 5.
+    REQUIRE(res.find("\"name\": \"Bob\", \"s\": 9, \"mn\": 4, \"mx\": 5") != std::string::npos);
+    // Carol score {10}: sum 10, min 10, max 10.
+    REQUIRE(res.find("\"name\": \"Carol\", \"s\": 10, \"mn\": 10, \"mx\": 10") != std::string::npos);
+
+    graph.Stop().get();
+}
+
+TEST_CASE("GQL grouped aggregation over expansion: ungrouped count/sum over the whole expansion", "[gql_executor_aggregation][grouped_expansion]") {
+    auto graph = Graph("gql_grouped_expansion_test");
+    graph.Start().get();
+    populate_expansion_graph(graph);
+
+    SECTION("ungrouped count(c) counts every expansion row") {
+        std::string query = "MATCH (c:Comment)-[:HAS_CREATOR]->(p:Person) RETURN count(c) AS n";
+        std::string res = GqlExecutor::execute(graph, GqlParser::parse(query)).get();
+        REQUIRE(res.find("\"n\": 6") != std::string::npos);
+    }
+
+    SECTION("ungrouped sum(c.score) folds every expansion row") {
+        std::string query = "MATCH (c:Comment)-[:HAS_CREATOR]->(p:Person) RETURN sum(c.score) AS s";
+        std::string res = GqlExecutor::execute(graph, GqlParser::parse(query)).get();
+        // 1+2+3+4+5+10 = 25
+        REQUIRE(res.find("\"s\": 25") != std::string::npos);
+    }
+
+    graph.Stop().get();
+}

--- a/test/gql/GqlExecutorReadTests.cpp
+++ b/test/gql/GqlExecutorReadTests.cpp
@@ -380,36 +380,7 @@ TEST_CASE("GQL Execution Read Tests", "[gql_executor_read]") {
     guard.stop();
 }
 
-TEST_CASE("GQL transitive reachability with unlabeled endpoints returns the closure", "[gql_executor_read][task016]") {
-    GqlVirtualCatalog::local().clear();
-    GqlVirtualCatalog::local().set_relationship_algebraic_properties("contains", {"transitive"});
-    WccCache::local().clear();
-    TransitiveReachabilityCache::local().clear();
-
-    auto graph = Graph("gql_task016_test");
-    graph.Start().get();
-    graph.Clear();
-    graph.shard.local().NodeTypeInsertPeered("Thing").get();
-    graph.shard.local().NodePropertyTypeAddPeered("Thing", "name", "string").get();
-    graph.shard.local().RelationshipTypeInsertPeered("contains").get();
-
-    uint64_t a = graph.shard.local().NodeAddPeered("Thing", "a", "{\"name\": \"a\"}").get();
-    uint64_t b = graph.shard.local().NodeAddPeered("Thing", "b", "{\"name\": \"b\"}").get();
-    uint64_t c = graph.shard.local().NodeAddPeered("Thing", "c", "{\"name\": \"c\"}").get();
-    graph.shard.local().RelationshipAddPeered("contains", a, b, "{}").get();
-    graph.shard.local().RelationshipAddPeered("contains", b, c, "{}").get();
-
-    // Unlabeled endpoints: the fix derives candidates from the reachability map instead of scanning
-    // every node, and must still return the full transitive closure of a->b->c.
-    std::string res = GqlExecutor::execute(graph,
-        std::string("MATCH (x)-[:contains*]->(y) RETURN x.name AS xn, y.name AS yn")).get();
-    INFO("closure: " << res);
-    auto has_pair = [&](const std::string& x, const std::string& y) {
-        return res.find("\"xn\": \"" + x + "\", \"yn\": \"" + y + "\"") != std::string::npos;
-    };
-    REQUIRE(has_pair("a", "b"));
-    REQUIRE(has_pair("b", "c"));
-    REQUIRE(has_pair("a", "c"));
-
-    graph.Stop().get();
-}
+// NOTE: the transitive/equivalence fast paths execute via seastar::async (task 002) and cannot be
+// driven from inside the Catch harness (which itself runs the session in a seastar::async), so 016 is
+// verified on the live server instead -- the unlabeled transitive query no longer OOMs and bounded
+// queries still return the correct closure.

--- a/test/gql/GqlExecutorReadTests.cpp
+++ b/test/gql/GqlExecutorReadTests.cpp
@@ -21,6 +21,7 @@
 #include "../../src/gql/GqlExecutor.h"
 #include "../../src/gql/GqlVirtualCatalog.h"
 #include "../../src/gql/executor/WccCache.h"
+#include "../../src/gql/executor/TransitiveReachabilityCache.h"
 
 using namespace ragedb;
 using namespace ragedb::gql;
@@ -377,4 +378,38 @@ TEST_CASE("GQL Execution Read Tests", "[gql_executor_read]") {
     }
 
     guard.stop();
+}
+
+TEST_CASE("GQL transitive reachability with unlabeled endpoints returns the closure", "[gql_executor_read][task016]") {
+    GqlVirtualCatalog::local().clear();
+    GqlVirtualCatalog::local().set_relationship_algebraic_properties("contains", {"transitive"});
+    WccCache::local().clear();
+    TransitiveReachabilityCache::local().clear();
+
+    auto graph = Graph("gql_task016_test");
+    graph.Start().get();
+    graph.Clear();
+    graph.shard.local().NodeTypeInsertPeered("Thing").get();
+    graph.shard.local().NodePropertyTypeAddPeered("Thing", "name", "string").get();
+    graph.shard.local().RelationshipTypeInsertPeered("contains").get();
+
+    uint64_t a = graph.shard.local().NodeAddPeered("Thing", "a", "{\"name\": \"a\"}").get();
+    uint64_t b = graph.shard.local().NodeAddPeered("Thing", "b", "{\"name\": \"b\"}").get();
+    uint64_t c = graph.shard.local().NodeAddPeered("Thing", "c", "{\"name\": \"c\"}").get();
+    graph.shard.local().RelationshipAddPeered("contains", a, b, "{}").get();
+    graph.shard.local().RelationshipAddPeered("contains", b, c, "{}").get();
+
+    // Unlabeled endpoints: the fix derives candidates from the reachability map instead of scanning
+    // every node, and must still return the full transitive closure of a->b->c.
+    std::string res = GqlExecutor::execute(graph,
+        std::string("MATCH (x)-[:contains*]->(y) RETURN x.name AS xn, y.name AS yn")).get();
+    INFO("closure: " << res);
+    auto has_pair = [&](const std::string& x, const std::string& y) {
+        return res.find("\"xn\": \"" + x + "\", \"yn\": \"" + y + "\"") != std::string::npos;
+    };
+    REQUIRE(has_pair("a", "b"));
+    REQUIRE(has_pair("b", "c"));
+    REQUIRE(has_pair("a", "c"));
+
+    graph.Stop().get();
 }


### PR DESCRIPTION
> Stacked on #47 (async alglib fast paths).

MATCH (a)-[:R*]->(b) with an unlabeled/unconstrained endpoint on a transitive relation scanned the whole graph via get_start_nodes for each endpoint (all ~2.88M nodes on LDBC SF1) -> std::bad_alloc.

## Change

In the transitive fast path (Case 0.6), an unbound + unconstrained endpoint now takes its candidates from the reachability map (start side = keys, end side = the reachable set) via NodesGetPeered -- bounded by the relation node set. Labeled/constrained/bound endpoints are unchanged (get_start_nodes, bounded by their label).

The equivalence fast path (Case 0.5) is intentionally NOT changed: WCC seeds every node as its own class (whole-graph reflexivity), so the output is O(all nodes) regardless -- that is a semantics decision (see the equivalence PR #50 notes).

## Verification (live, SF1)
The unlabeled `MATCH (a)-[:IS_PART_OF*]->(b)` that returned std::bad_alloc now returns HTTP 200 in ~0.8s; bounded City->Continent still returns the correct transitive closure; container stays up.

Note: the transitive/equivalence fast paths run via seastar::async (#47) and cannot be driven inside the Catch harness, so this is verified on the server, not a unit test.