### PR TITLE
feat(gql): implement WITH query pipelining

### DIFF
--- a/src/gql/GqlAst.h
+++ b/src/gql/GqlAst.h
@@ -499,6 +499,11 @@ struct GqlQuery {
     std::vector<SortSpec> order_by;          ///< Sequence of sort specifications.
     std::optional<uint64_t> limit;           ///< Optional maximum number of rows to return.
 
+    /// WITH-pipeline prefix segments. Each entry is a sub-query (matches + WHERE + WITH projection +
+    /// ORDER BY/LIMIT/DISTINCT) whose projected rows feed forward as input bindings to the next
+    /// segment; the enclosing GqlQuery is the final segment ending in RETURN. Empty means no WITH.
+    std::vector<std::shared_ptr<GqlQuery>> with_segments;
+
     // DDL schema controls
     std::optional<SchemaOperation> schema_op;
 
@@ -545,6 +550,10 @@ struct GqlQuery {
         }
         
         copy.limit = limit;
+        copy.with_segments.reserve(with_segments.size());
+        for (const auto& seg : with_segments) {
+            copy.with_segments.push_back(std::make_shared<GqlQuery>(seg->clone()));
+        }
         copy.schema_op = schema_op;
         copy.outer_vars = outer_vars;
         copy.has_unnested_subquery = has_unnested_subquery;

--- a/src/gql/GqlExecutor.cpp
+++ b/src/gql/GqlExecutor.cpp
@@ -36,6 +36,7 @@
 #include "executor/LftjExecutor.h"
 
 #include <sstream>
+#include <optional>
 #include <unordered_set>
 #include <unordered_map>
 #include <set>
@@ -157,7 +158,49 @@ struct GqlRowOuterVarsLess {
  * @param query_ptr Shared pointer to the GQL query.
  * @return A future resolving to a QueryResult containing columns and values.
  */
-static seastar::future<QueryResult> execute_query_internal(ragedb::Graph& graph, std::shared_ptr<GqlQuery> query_ptr) {
+static seastar::future<QueryResult> execute_query_internal(ragedb::Graph& graph, std::shared_ptr<GqlQuery> query_ptr, std::optional<std::vector<GqlRow>> incoming = std::nullopt);
+
+/**
+ * @brief Convert a completed segment's QueryResult into input rows for the next WITH-pipeline
+ *        segment: each projected output column becomes a binding under its column name.
+ */
+static std::vector<GqlRow> query_result_to_rows(const QueryResult& res) {
+    std::vector<GqlRow> rows;
+    rows.reserve(res.rows.size());
+    for (const auto& r : res.rows) {
+        GqlRow gr;
+        for (size_t i = 0; i < res.column_names.size() && i < r.size(); ++i) {
+            gr.bindings[res.column_names[i]] = r[i];
+        }
+        rows.push_back(std::move(gr));
+    }
+    return rows;
+}
+
+/**
+ * @brief Execute WITH-pipeline segments [idx..], piping each one's projected rows into the next, and
+ *        return the rows to feed into the final (RETURN) segment. Stops early if a segment is empty.
+ */
+static seastar::future<std::vector<GqlRow>> execute_with_segments(
+        ragedb::Graph& graph, std::shared_ptr<GqlQuery> query_ptr, size_t idx,
+        std::optional<std::vector<GqlRow>> incoming) {
+    if (idx >= query_ptr->with_segments.size()) {
+        return seastar::make_ready_future<std::vector<GqlRow>>(
+            incoming.has_value() ? std::move(*incoming) : std::vector<GqlRow>{});
+    }
+    auto seg = query_ptr->with_segments[idx];
+    return execute_query_internal(graph, seg, std::move(incoming)).then(
+        [&graph, query_ptr, idx](QueryResult res) {
+            std::vector<GqlRow> rows = query_result_to_rows(res);
+            if (rows.empty()) {
+                return seastar::make_ready_future<std::vector<GqlRow>>(std::vector<GqlRow>{});
+            }
+            return execute_with_segments(graph, query_ptr, idx + 1,
+                std::optional<std::vector<GqlRow>>(std::move(rows)));
+        });
+}
+
+static seastar::future<QueryResult> execute_query_internal(ragedb::Graph& graph, std::shared_ptr<GqlQuery> query_ptr, std::optional<std::vector<GqlRow>> incoming) {
     if (query_ptr->no_op) {
         QueryResult query_res;
         for (size_t i = 0; i < query_ptr->returns.size(); ++i) {
@@ -199,6 +242,17 @@ static seastar::future<QueryResult> execute_query_internal(ragedb::Graph& graph,
             query_res.column_names.push_back(key);
         }
         return seastar::make_ready_future<QueryResult>(std::move(query_res));
+    }
+
+    // WITH pipeline: execute the prefix segments (each projecting rows forward), then run the final
+    // RETURN segment on the piped rows. The final segment is this query with its with_segments removed.
+    if (!query_ptr->with_segments.empty()) {
+        return execute_with_segments(graph, query_ptr, 0, std::move(incoming))
+        .then([&graph, query_ptr](std::vector<GqlRow> piped) {
+            auto final_seg = std::make_shared<GqlQuery>(query_ptr->clone());
+            final_seg->with_segments.clear();
+            return execute_query_internal(graph, final_seg, std::optional<std::vector<GqlRow>>(std::move(piped)));
+        });
     }
 
     // 1. Handle Set Operations (UNION, UNION ALL, INTERSECT, INTERSECT ALL)
@@ -437,8 +491,11 @@ static seastar::future<QueryResult> execute_query_internal(ragedb::Graph& graph,
         }
     }
 
-    // 5. Execute matching patterns recursively using sharded traversal
-    IntermediateResult initial_res(std::vector<GqlRow>{ GqlRow{} });
+    // 5. Execute matching patterns recursively using sharded traversal. WITH-pipeline continuation
+    // segments start from the rows piped in from the previous segment rather than a single empty row.
+    IntermediateResult initial_res = incoming.has_value()
+        ? IntermediateResult(std::move(*incoming))
+        : IntermediateResult(std::vector<GqlRow>{ GqlRow{} });
     auto is_sorted_shared = std::make_shared<bool>(false);
 
     auto is_query_cyclic = [](const std::vector<MatchStatement>& matches) -> bool {

--- a/src/gql/GqlLexer.cpp
+++ b/src/gql/GqlLexer.cpp
@@ -295,6 +295,7 @@ std::vector<Token> GqlLexer::tokenize(const std::string& input) {
             else if (upper_name == "OPTIONAL") type = TokenType::OPTIONAL;
             else if (upper_name == "WHERE") type = TokenType::WHERE;
             else if (upper_name == "RETURN") type = TokenType::RETURN;
+            else if (upper_name == "WITH") type = TokenType::WITH;
             else if (upper_name == "DISTINCT") type = TokenType::DISTINCT;
             else if (upper_name == "LIMIT") type = TokenType::LIMIT;
             else if (upper_name == "ASC" || upper_name == "ASCENDING") type = TokenType::ASC;

--- a/src/gql/GqlLexer.h
+++ b/src/gql/GqlLexer.h
@@ -42,6 +42,7 @@ enum class TokenType {
     MATCH,
     OPTIONAL,
     RETURN,
+    WITH,
     DISTINCT,
     ORDER_BY,
     LIMIT,

--- a/src/gql/GqlOptimizer.cpp
+++ b/src/gql/GqlOptimizer.cpp
@@ -411,6 +411,16 @@ void GqlOptimizer::optimize(GqlQuery& query) {
         return;
     }
 
+    // Optimize each WITH-pipeline segment (each is a sub-query with its own patterns).
+    for (auto& seg : query.with_segments) {
+        if (seg) optimize(*seg);
+    }
+    // A segment with no MATCH (e.g. WITH p RETURN p.name) has no pattern to optimize, and the
+    // match-oriented passes below assume at least one MATCH -- skip them.
+    if (query.matches.empty()) {
+        return;
+    }
+
     // Phase 1: Expand any virtual views recursively up to a limit of 20.
     expand_views_recursive(query);
 

--- a/src/gql/GqlParser.cpp
+++ b/src/gql/GqlParser.cpp
@@ -108,10 +108,17 @@ static void validate_insert_label_expr(const std::shared_ptr<LabelExpression>& e
  * @throws std::runtime_error If syntax errors are encountered.
  */
 GqlQuery GqlParser::parse_single_query() {
-    GqlQuery query;
-
+    std::vector<std::shared_ptr<GqlQuery>> with_segments;
+    std::unique_ptr<Expression> pending_having;
     int match_id_counter = 0;
     int optional_group_counter = 0;
+
+    while (true) {
+    GqlQuery query;
+    // A WHERE that followed a preceding WITH filters the rows piped into this segment.
+    if (pending_having) {
+        query.where_expr = std::move(pending_having);
+    }
     // Parse MATCH/OPTIONAL MATCH clauses
     while (check(TokenType::MATCH) || (check(TokenType::OPTIONAL) && peek(1).type == TokenType::MATCH)) {
         MatchStatement stmt;
@@ -315,9 +322,14 @@ GqlQuery GqlParser::parse_single_query() {
         }
     }
 
-    // Parse optional global WHERE clause
+    // Parse optional global WHERE clause (AND-combined with any HAVING carried in from a prior WITH).
     if (match(TokenType::WHERE)) {
-        query.where_expr = parse_expression();
+        auto w = parse_expression();
+        if (query.where_expr) {
+            query.where_expr = std::make_unique<BinaryOpExpr>(BinaryOpKind::AND, std::move(query.where_expr), std::move(w));
+        } else {
+            query.where_expr = std::move(w);
+        }
     }
 
     // Parse Write Operations (INSERT, SET, REMOVE, DELETE, DETACH)
@@ -385,9 +397,56 @@ GqlQuery GqlParser::parse_single_query() {
         }
     }
 
-    // Verify we have at least one MATCH or write operation
-    if (query.matches.empty() && query.writes.empty()) {
+    // Verify we have at least one MATCH or write operation (a continuation segment after WITH may
+    // have neither -- it operates on the rows piped in from the previous segment).
+    if (query.matches.empty() && query.writes.empty() && with_segments.empty()) {
         throw std::runtime_error("Query must contain at least one MATCH or write clause");
+    }
+
+    // A WITH clause closes a pipeline segment: project (optionally DISTINCT / ORDER BY / LIMIT) and
+    // feed the projected rows forward as bindings to the next segment.
+    if (match(TokenType::WITH)) {
+        if (match(TokenType::DISTINCT)) {
+            query.distinct = true;
+        }
+        do {
+            ReturnItem item;
+            item.expr = parse_expression();
+            if (match(TokenType::AS)) {
+                std::string alias = peek().text;
+                consume(TokenType::NAME, "Expected alias name after 'AS'");
+                item.alias = alias;
+            }
+            query.returns.push_back(std::move(item));
+        } while (match(TokenType::COMMA));
+
+        if (match(TokenType::ORDER_BY)) {
+            do {
+                SortSpec spec;
+                spec.expr = parse_expression();
+                if (match(TokenType::ASC)) {
+                    spec.ascending = true;
+                } else if (match(TokenType::DESC)) {
+                    spec.ascending = false;
+                } else {
+                    spec.ascending = true;
+                }
+                query.order_by.push_back(std::move(spec));
+            } while (match(TokenType::COMMA));
+        }
+        if (match(TokenType::LIMIT)) {
+            std::string num_str = peek().text;
+            consume(TokenType::NUMBER, "Expected integer limit value");
+            query.limit = std::stoull(num_str);
+        }
+        // A WHERE right after WITH is a HAVING filter on the projected rows; it applies to the next
+        // segment, which sees the projected bindings.
+        if (match(TokenType::WHERE)) {
+            pending_having = parse_expression();
+        }
+
+        with_segments.push_back(std::make_shared<GqlQuery>(std::move(query)));
+        continue;
     }
 
     // Parse RETURN clause (optional if we performed writes, otherwise mandatory)
@@ -412,7 +471,9 @@ GqlQuery GqlParser::parse_single_query() {
         }
     }
 
+    query.with_segments = std::move(with_segments);
     return query;
+    }  // end while(true) over pipeline segments
 }
 
 GqlQuery GqlParser::parse_query() {

--- a/src/gql/GqlTypechecker.cpp
+++ b/src/gql/GqlTypechecker.cpp
@@ -531,6 +531,14 @@ void GqlTypechecker::check_query(const GqlQuery& query) {
         return;
     }
 
+    // WITH-pipeline queries carry variables across segment horizons (a later segment references
+    // variables projected by an earlier WITH, not bound by its own MATCH). The typechecker is not
+    // WITH-aware and would flag those piped variables as unbound; such queries are validated during
+    // execution instead.
+    if (!query.with_segments.empty()) {
+        return;
+    }
+
     if (query.kind != QueryKind::SINGLE) {
         if (query.left) {
             check_query(*query.left);

--- a/test/gql/GqlExecutorReadTests.cpp
+++ b/test/gql/GqlExecutorReadTests.cpp
@@ -378,3 +378,47 @@ TEST_CASE("GQL Execution Read Tests", "[gql_executor_read]") {
 
     guard.stop();
 }
+
+TEST_CASE("GQL WITH query pipelining", "[gql_executor_read][task_with]") {
+    auto graph = Graph("gql_with_test");
+    graph.Start().get();
+    graph.Clear();
+    graph.shard.local().NodeTypeInsertPeered("Person").get();
+    graph.shard.local().NodePropertyTypeAddPeered("Person", "name", "string").get();
+    graph.shard.local().NodePropertyTypeAddPeered("Person", "age", "integer").get();
+    graph.shard.local().RelationshipTypeInsertPeered("KNOWS").get();
+    uint64_t a = graph.shard.local().NodeAddPeered("Person", "alice", "{\"name\": \"Alice\", \"age\": 30}").get();
+    uint64_t b = graph.shard.local().NodeAddPeered("Person", "bob", "{\"name\": \"Bob\", \"age\": 35}").get();
+    uint64_t c = graph.shard.local().NodeAddPeered("Person", "carol", "{\"name\": \"Carol\", \"age\": 40}").get();
+    graph.shard.local().RelationshipAddPeered("KNOWS", a, b, "{}").get();
+    graph.shard.local().RelationshipAddPeered("KNOWS", a, c, "{}").get();
+
+    SECTION("a trivial WITH passes a node through to RETURN") {
+        std::string res = GqlExecutor::execute(graph,
+            std::string("MATCH (p:Person {name: 'Alice'}) WITH p RETURN p.name AS n")).get();
+        REQUIRE(res.find("Alice") != std::string::npos);
+    }
+
+    SECTION("WITH stages a node into a second MATCH") {
+        std::string res = GqlExecutor::execute(graph,
+            std::string("MATCH (a:Person {name: 'Alice'}) WITH a MATCH (a)-[:KNOWS]->(f:Person) RETURN f.name AS fn")).get();
+        REQUIRE(res.find("Bob") != std::string::npos);
+        REQUIRE(res.find("Carol") != std::string::npos);
+    }
+
+    SECTION("WITH mid-pipeline aggregation") {
+        std::string res = GqlExecutor::execute(graph,
+            std::string("MATCH (a:Person)-[:KNOWS]->(f:Person) WITH a, count(f) AS cnt RETURN a.name AS n, cnt")).get();
+        REQUIRE(res.find("\"n\": \"Alice\", \"cnt\": 2") != std::string::npos);
+    }
+
+    SECTION("WITH ORDER BY + LIMIT stages the top row into the next segment") {
+        std::string res = GqlExecutor::execute(graph,
+            std::string("MATCH (p:Person) WITH p ORDER BY p.age DESC LIMIT 1 RETURN p.name AS n")).get();
+        REQUIRE(res.find("Carol") != std::string::npos);
+        REQUIRE(res.find("Alice") == std::string::npos);
+        REQUIRE(res.find("Bob") == std::string::npos);
+    }
+
+    graph.Stop().get();
+}


### PR DESCRIPTION
Adds openCypher `WITH` support to the GQL interface -- query pipelining across segment horizons. Without it, only single-MATCH queries run; `WITH` unblocks multi-phase queries (staging, mid-query aggregation), which is the single biggest gap for running LDBC SNB IC/BI over `/db/{g}/gql`.

## What
- **Lexer:** a standalone `WITH` keyword token (`STARTS`/`ENDS WITH` already consume their `WITH` via lookahead, so this is safe).
- **AST:** `GqlQuery.with_segments` -- an ordered list of prefix segments, each ending in a `WITH` projection; the enclosing query is the final `RETURN` segment. `clone()` deep-copies them.
- **Parser:** `parse_single_query` now loops over pipeline segments. `WITH` closes a segment (projection, optional `DISTINCT`/`ORDER BY`/`LIMIT`); a `WHERE` right after `WITH` becomes a HAVING carried into the next segment.
- **Executor:** `execute_query_internal` takes optional incoming rows; for a pipelined query it runs each segment, projecting its rows into bindings fed to the next, then runs the final `RETURN` segment. Reuses all existing match/filter/aggregate/order/limit machinery per segment.
- **Optimizer/typechecker:** optimize each segment; skip the match-oriented passes on a no-MATCH segment; bypass the (WITH-unaware) static typechecker for pipelined queries (validated at execution).

## Verification
Unit tests (all pass): trivial `WITH` pass-through, `WITH` staging a node into a second MATCH (IS5 shape), mid-pipeline aggregation (`WITH a, count(f) AS cnt`), and `WITH ... ORDER BY ... LIMIT` staging. Also exercised live on LDBC SF1.

Follow-up (separate): `count(DISTINCT x)` (part 2 of the same gap) is not in this PR.